### PR TITLE
Implement QSearch.

### DIFF
--- a/Backend/Data/MoveTranspositionTable.cs
+++ b/Backend/Data/MoveTranspositionTable.cs
@@ -27,9 +27,11 @@ public unsafe class MoveTranspositionTable
             HashFilter = i;
         }
 
-        Internal = new MoveTranspositionTableEntry[HashFilter];
+        Internal = new MoveTranspositionTableEntry[HashFilter + 1];
 
-        Parallel.For(0, HashFilter, i => Internal[i] = new MoveTranspositionTableEntry());
+        Parallel.For(0, HashFilter + 1, i => 
+            Internal[i] = new MoveTranspositionTableEntry()
+        );
 
 #if DEBUG
         Console.WriteLine("Allocated " + HashFilter * sizeof(MoveTranspositionTableEntry) + 

--- a/Backend/Data/Struct/MoveList.cs
+++ b/Backend/Data/Struct/MoveList.cs
@@ -240,6 +240,60 @@ public ref struct MoveList
                 );
         }
     }
+    
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public MoveList(Board board, Square from, Piece piece, PieceColor color, ref BitBoard horizontalVertical, 
+        ref BitBoard diagonal, ref BitBoard checks)
+    {
+        Board = board;
+        From = from;
+        Moves = BitBoard.Default;
+        Promotion = false;
+        Hv = horizontalVertical;
+        D = diagonal;
+        C = checks;
+        
+        // Generate Legal Moves
+        switch (piece) {
+            case Piece.Pawn:
+                LegalPawnMoveSet(color);
+                break;
+            case Piece.Rook:
+                LegalRookMoveSet(color);
+                break;
+            case Piece.Knight:
+                LegalKnightMoveSet(color);
+                break;
+            case Piece.Bishop:
+                LegalBishopMoveSet(color);
+                break;
+            case Piece.Queen:
+                LegalQueenMoveSet(color);
+                break;
+            case Piece.King:
+                LegalKingMoveSet(color);
+                break;
+            case Piece.Empty:
+            default:
+                throw InvalidMoveLookupException.FromBoard(
+                    board, 
+                    "Cannot generate move for empty piece: " + from
+                );
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public MoveList(Board board, Square from, ref BitBoard horizontalVertical, 
+        ref BitBoard diagonal, ref BitBoard checks)
+    {
+        Board = board;
+        From = from;
+        Moves = BitBoard.Default;
+        Promotion = false;
+        Hv = horizontalVertical;
+        D = diagonal;
+        C = checks;
+    }
 
     public MoveList(Board board, PieceColor color)
     {

--- a/Backend/Data/Struct/MoveList.cs
+++ b/Backend/Data/Struct/MoveList.cs
@@ -315,6 +315,11 @@ public ref struct MoveList
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public void LegalPawnMoveSetCapture(PieceColor color)
     {
+        if (Hv[From]) {
+            // If pawn is horizontally pinned, then we have no moves.
+            return;
+        }
+        
         PieceColor oppositeColor = Util.OppositeColor(color);
         BitBoard opposite = Board.All(oppositeColor);
         Square epPieceSq = Square.Na;

--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -82,7 +82,7 @@ public readonly ref struct OrderedMoveList
             while (fromIterator.MoveNext()) {
                 MoveList moveList = new(
                     board, from, Piece.Pawn, board.ColorToMove, 
-                    ref hv, ref d, ref checks, false
+                    ref hv, ref d, ref checks
                 );
                 BitBoardIterator moves = moveList.Moves.GetEnumerator();
                 Square move = moves.Current;
@@ -116,7 +116,7 @@ public readonly ref struct OrderedMoveList
                 while (fromIterator.MoveNext()) {
                     MoveList moveList = new(
                         board, from, (Piece)piece, board.ColorToMove, 
-                        ref hv, ref d, ref checks, false
+                        ref hv, ref d, ref checks
                     );
                     BitBoardIterator moves = moveList.Moves.GetEnumerator();
                     Square move = moves.Current;
@@ -142,7 +142,7 @@ public readonly ref struct OrderedMoveList
         while (fromIterator.MoveNext()) {
             MoveList moveList = new(
                 board, from, Piece.King, board.ColorToMove, 
-                ref hv, ref d, ref checks, false
+                ref hv, ref d, ref checks
             );
             BitBoardIterator moves = moveList.Moves.GetEnumerator();
             Square move = moves.Current;

--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -186,6 +186,11 @@ public readonly ref struct OrderedMoveList
                 MoveList moveList = new(board, from, ref hv, ref d, ref checks);
                 moveList.LegalPawnMoveSetCapture(board.ColorToMove);
                 BitBoardIterator moves = moveList.Moves.GetEnumerator();
+                // MoveList moveList = new(
+                //     board, from, Piece.Pawn, board.ColorToMove, 
+                //     ref hv, ref d, ref checks
+                // );
+                // BitBoardIterator moves = (moveList.Moves & opposite).GetEnumerator();
                 Square move = moves.Current;
                 
                 while (moves.MoveNext()) {

--- a/Backend/Data/Struct/SearchedMove.cs
+++ b/Backend/Data/Struct/SearchedMove.cs
@@ -8,6 +8,8 @@ public readonly struct SearchedMove
 #pragma warning restore CS0660, CS0661
 {
 
+    public static readonly SearchedMove Default = new(Square.Na, Square.Na, Promotion.None, 0);
+
     public readonly Square From;
     public readonly Square To;
     public readonly Promotion Promotion;

--- a/Backend/Engine/EngineBoard.cs
+++ b/Backend/Engine/EngineBoard.cs
@@ -26,7 +26,7 @@ public class EngineBoard : Board
         base(boardData, turnData, castlingData, enPassantTargetData) => History = new HashHistory();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsRepetition() => History.Count(ZobristHash) > 2;
+    public bool IsRepetition() => History.Count(ZobristHash) > 1;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RevertMove Move(ref OrderedMoveEntry move)

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -238,6 +238,7 @@ public class MoveSearch
         return bestEvaluation;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private int QSearch(EngineBoard board, int plyFromRoot, int depth, int alpha, int beta)
     {
         #region Cancellation
@@ -270,15 +271,14 @@ public class MoveSearch
         OrderedMoveList moveList = new(ref moveSpan);
         int moveCount = moveList.QSearchMoveGeneration(board, SearchedMove.Default);
         
-        if (moveCount == 0) {
-            // If we had no moves at this depth, we should check if our king is in check. If our king is in check, it
-            // means we lost as nothing can save the king anymore. Otherwise, it's a stalemate where we can't really do
-            // anything but the opponent cannot kill our king either. It isn't a beneficial position or a position
-            // that's bad for us, so returning 0 is fine here.
-            PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
-            Square kingSq = board.KingLoc(board.ColorToMove);
-            return MoveList.UnderAttack(board, kingSq, oppositeColor) ? -MATE + plyFromRoot : 0;
-        }
+        // if (moveCount == 0) {
+        //     // If we had no moves at this depth, we should check if our king is in check. If our king is in check, it
+        //     // means we lost as nothing can save the king anymore. Otherwise, we should just return our best evaluation
+        //     // so far.
+        //     PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        //     Square kingSq = board.KingLoc(board.ColorToMove);
+        //     return MoveList.UnderAttack(board, kingSq, oppositeColor) ? -MATE + plyFromRoot : alpha;
+        // }
 
         #endregion
         

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -306,7 +306,12 @@ public class MoveSearch
             // Undo the move.
             board.UndoMove(ref rv);
 
+            // In the case our evaluation is better than our beta, it means the evaluation is too good and we can
+            // return early here.
             if (evaluation >= beta) return beta;
+            
+            // If the evaluation is better than our alpha, we should set our new alpha to amke sure we account for next
+            // good moves if they exist, while making sure we don't dismiss this good move.
             if (evaluation > alpha) alpha = evaluation;
             
             i++;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -27,7 +27,7 @@ public class MoveSearch
     {
         Board = board;
         Table = table;
-        BestMove = new SearchedMove(Square.Na, Square.Na, Promotion.None, NEG_INFINITY);
+        BestMove = SearchedMove.Default;
         Token = token;
     }
 
@@ -45,7 +45,8 @@ public class MoveSearch
         try {
             int depth = 1;
             while (!Token.IsCancellationRequested && depth <= selectedDepth) {
-                bestMove = SearchAndReturn(depth);
+                AbSearch(Board, 0, depth, NEG_INFINITY, POS_INFINITY);
+                bestMove = BestMove;
                 DepthSearchLog(depth);
                 depth++;
             }
@@ -99,7 +100,7 @@ public class MoveSearch
 
         ref MoveTranspositionTableEntry storedEntry = ref Table[board.ZobristHash];
         bool valid = storedEntry.Type != MoveTranspositionTableEntryType.Invalid;
-        SearchedMove transpositionMove = new(Square.Na, Square.Na, Promotion.None, 0);
+        SearchedMove transpositionMove = SearchedMove.Default;
         if (valid && storedEntry.ZobristHash == board.ZobristHash && storedEntry.Depth >= depth && plyFromRoot != 0) {
             // Check what type of evaluation we have stored.
             switch (storedEntry.Type) {

--- a/Backend/Util.cs
+++ b/Backend/Util.cs
@@ -23,15 +23,23 @@ public static class Util
     // ReSharper disable once InconsistentNaming
     public static ref T AA<T>(this T[] array, int index)
     {
+#if DEBUG
+        return ref array[index];
+#else
         return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
+#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // ReSharper disable once InconsistentNaming
     public static ref T DJAA<T>(this T[][] array, int firstIndex, int secondIndex)
     {
+#if DEBUG
+        return ref array.AA(firstIndex)[secondIndex];
+#else
         return 
             ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array.AA(firstIndex)), secondIndex);
+#endif
     }
 
 }


### PR DESCRIPTION
## Current Problem

As of now, StockNemo searches to a depth X within a certain time Y. However, past that certain time Y, StockNemo cannot search more and is limited to depth X. At depth X, a move is found that is evaluated to be stronger for StockNemo, but it's entirely possible that at depth X + 1 or X + 2 or some X + Z depth after that, is worse for StockNemo. This is regarded as the Horizon Effect where the engine cannot see past the horizon, potentially trapping itself.

## Solution - QSearch
QSearch aims to solve the problem by glancing over the horizon. It will only look for moves that can significantly damage the evaluation (Capture Moves for now, but may be worth including promotions). It will search far beyond the normal limit, and thus be able to significantly improve search reliability. 

## ELO Difference
### TC: 10s + 1s
Using `popularpos_lichess.epd`:
```
Score of StockNemo vs StockNemo-OLD: 47 - 3 - 30 [0.775]
...      StockNemo playing White: 25 - 0 - 15  [0.813] 40
...      StockNemo playing Black: 22 - 3 - 15  [0.738] 40
...      White vs Black: 28 - 22 - 30  [0.537] 80
Elo difference: 214.8 +/- 63.2, LOS: 100.0 %, DrawRatio: 37.5 %
80 of 80 games finished.
```
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo vs StockNemo-OLD: 47 - 4 - 29 [0.769]
...      StockNemo playing White: 27 - 1 - 12  [0.825] 40
...      StockNemo playing Black: 20 - 3 - 17  [0.713] 40
...      White vs Black: 30 - 21 - 29  [0.556] 80
Elo difference: 208.7 +/- 64.5, LOS: 100.0 %, DrawRatio: 36.3 %
80 of 80 games finished.
```

### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo vs StockNemo-OLD: 52 - 2 - 26 [0.813]
...      StockNemo playing White: 28 - 0 - 12  [0.850] 40
...      StockNemo playing Black: 24 - 2 - 14  [0.775] 40
...      White vs Black: 30 - 24 - 26  [0.537] 80
Elo difference: 254.7 +/- 68.4, LOS: 100.0 %, DrawRatio: 32.5 %
80 of 80 games finished.
```