### PR TITLE
Implement Null Move Pruning.

### DIFF
--- a/Backend/Engine/EngineBoard.cs
+++ b/Backend/Engine/EngineBoard.cs
@@ -43,6 +43,32 @@ public class EngineBoard : Board
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RevertNullMove NullMove()
+    {
+        RevertNullMove rv = RevertNullMove.FromBitBoardMap(ref Map);
+        
+        if (Map.EnPassantTarget != Square.Na) Zobrist.HashEp(ref Map.ZobristHash, Map.EnPassantTarget);
+        Map.EnPassantTarget = Square.Na;
+
+        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Zobrist.FlipTurnInHash(ref Map.ZobristHash);
+
+        return rv;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UndoNullMove(RevertNullMove rv)
+    {
+        if (rv.EnPassantTarget != Square.Na) {
+            Map.EnPassantTarget = rv.EnPassantTarget;
+            Zobrist.HashEp(ref Map.ZobristHash, rv.EnPassantTarget);
+        }
+
+        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Zobrist.FlipTurnInHash(ref Map.ZobristHash);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RevertMove Move(ref OrderedMoveEntry move)
     {
         History.Append(ZobristHash);

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -171,8 +171,8 @@ public class MoveSearch
             // For null move pruning, we give the turn to the opponent and let them make the move.
             RevertNullMove rv = board.NullMove();
             // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
-            // The idea is that if there are cutoffs, most will be found using this reduced
-            // search and we can cutoff this branch earlier.
+            // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff
+            // this branch earlier.
             // Being reduced, it's not as expensive as the regular search (especially if we can avoid a jump into
             // QSearch).
             int evaluation = -AbSearch(board, nextPlyFromRoot, reductionDepth, -beta, -beta + 1);

--- a/Backend/Engine/RevertNullMove.cs
+++ b/Backend/Engine/RevertNullMove.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.CompilerServices;
+using Backend.Data.Enum;
+using Backend.Data.Struct;
+
+namespace Backend.Engine;
+
+public ref struct RevertNullMove
+{
+
+    #region Data
+
+    public Square EnPassantTarget;
+
+    #endregion
+    
+    #region BitBoardMap based Constructor
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static RevertNullMove FromBitBoardMap(ref BitBoardMap map)
+    {
+        // Generate a RevertNullMove based on the current state of the map.
+        return new RevertNullMove()
+        {
+            EnPassantTarget = map.EnPassantTarget
+        };
+    }
+
+    #endregion
+
+}

--- a/Backend/Version.cs
+++ b/Backend/Version.cs
@@ -5,7 +5,7 @@ namespace Backend;
 public static class Version
 {
 
-    private const string VERSION = "2.0.0.1";
+    private const string VERSION = "2.0.0.2";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Get()


### PR DESCRIPTION
The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff this branch earlier.
Being a reduced search, it's not as expensive as the regular search (especially if we can avoid a jump into QSearch).

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo 2.0.0.2 vs StockNemo 2.0.0.1: 70 - 50 - 80 [0.550]
...      StockNemo 2.0.0.2 playing White: 41 - 21 - 38  [0.600] 100
...      StockNemo 2.0.0.2 playing Black: 29 - 29 - 42  [0.500] 100
...      White vs Black: 70 - 50 - 80  [0.550] 200
Elo difference: 34.9 +/- 37.5, LOS: 96.6 %, DrawRatio: 40.0 %
200 of 200 games finished.
```
```
Rank Name                          Elo     +/-   Games   Score    Draw 
   1 StockNemo Dev                 142      21     800   69.3%   31.4% 
   2 StockNemo 2.0.0.1             101      20     800   64.1%   32.8% 
   3 StockNemo 2.0.0.0              75      20     800   60.7%   35.1% 
   4 StockNemo 1.0.0.6            -124      22     800   32.9%   24.5% 
   5 apollo-64-popcnt             -210      29     800   23.0%    0.5% 

2000 of 2000 games finished.
```