### PR TITLE
Replace material values with the ones from Stockfish.

### DIFF
--- a/Backend/Data/MaterialDevelopmentTable.cs
+++ b/Backend/Data/MaterialDevelopmentTable.cs
@@ -7,8 +7,8 @@ public class MaterialDevelopmentTable
 {
     
     private static readonly int[] Material = {
-        82, 477, 337, 365, 1025, 0, 
-        94, 512, 281, 297,  936, 0
+        126, 1276, 781, 825, 2538, 0, 
+        208, 1380, 854, 915, 2682, 0
     };
 
     private static readonly int[] Internal = {

--- a/Backend/Version.cs
+++ b/Backend/Version.cs
@@ -5,7 +5,7 @@ namespace Backend;
 public static class Version
 {
 
-    private const string VERSION = "2.0.0.3";
+    private const string VERSION = "2.0.0.4";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Get()


### PR DESCRIPTION
This PR attempts the Stockfish Replacement Strategy.

It hopes that by replacing material values currently used by StockNemo, with the ones used by Stockfish (with miner alterations), one can achieve a higher ELO.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo 2.0.0.4 vs StockNemo 2.0.0.3: 50 - 76 - 74 [0.435]
...      StockNemo 2.0.0.4 playing White: 29 - 33 - 38  [0.480] 100
...      StockNemo 2.0.0.4 playing Black: 21 - 43 - 36  [0.390] 100
...      White vs Black: 72 - 54 - 74  [0.545] 200
Elo difference: -45.4 +/- 38.5, LOS: 1.0 %, DrawRatio: 37.0 %
200 of 200 games finished.
```