### PR TITLE
Implement Aspiration Search.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -79,7 +79,6 @@ public class MoveSearch
         }
 
         int research = 0;
-
         while (true) {
             #region Cancellation
 
@@ -91,10 +90,15 @@ public class MoveSearch
             #endregion
 
             #region Reset Window
+            
+            // We should reset our window if it's too far gone because the gradual increase isn't working.
 
             // In the case our alpha is far below our aspiration bound, we should reset it to negative infinity for
             // our research.
             if (alpha < -ASPIRATION_BOUND) alpha = NEG_INFINITY;
+            
+            // In the case our beta is far too above our aspiration bound, we should reset it to positive infinity for
+            // our research.
             if (beta > ASPIRATION_BOUND) beta = POS_INFINITY;
 
             #endregion

--- a/Backend/Version.cs
+++ b/Backend/Version.cs
@@ -5,7 +5,7 @@ namespace Backend;
 public static class Version
 {
 
-    private const string VERSION = "2.0.0.3";
+    private const string VERSION = "2.0.0.5";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Get()


### PR DESCRIPTION
Currently, we have a massive search space: `(-INF, +INF)`. This forces us to look at every branch, even if it's far too terrible. To dynamically change our search space in a narrow window, we use aspiration search.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo 2.0.0.5 vs StockNemo 2.0.0.3: 71 - 51 - 78 [0.550]
...      StockNemo 2.0.0.5 playing White: 44 - 21 - 35  [0.615] 100
...      StockNemo 2.0.0.5 playing Black: 27 - 30 - 43  [0.485] 100
...      White vs Black: 74 - 48 - 78  [0.565] 200
Elo difference: 34.9 +/- 37.8, LOS: 96.5 %, DrawRatio: 39.0 %
200 of 200 games finished.
```
```
Rank Name                          Elo     +/-   Games   Score    Draw 
   1 StockNemo Dev                 167      22     800   72.3%   28.4% 
   2 StockNemo 2.0.0.3             125      20     800   67.3%   32.5% 
   3 StockNemo 2.0.0.2             -61      19     800   41.4%   37.3% 
   4 StockNemo 2.0.0.1             -99      20     800   36.2%   34.4% 
   5 StockNemo 2.0.0.0            -124      20     800   32.9%   36.5% 

2000 of 2000 games finished.
```