### PR TITLE
Implement PV Line Logging with PV Line Storing.

### DIFF
--- a/Backend/Data/PrincipleVariationTable.cs
+++ b/Backend/Data/PrincipleVariationTable.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.CompilerServices;
+using Backend.Data.Struct;
+
+namespace Backend.Data;
+
+public class PrincipleVariationTable
+{
+
+    private const int SIZE = 64;
+
+    private readonly int[] Length = new int[SIZE];
+    private readonly OrderedMoveEntry[] Internal = new OrderedMoveEntry[SIZE * SIZE];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void InitializeLength(int ply) => Length.AA(ply) = ply;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Insert(int ply, ref OrderedMoveEntry move) => Internal.AA(ply * SIZE + ply) = move;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Copy(int currentPly, int nextPly) =>
+        Internal.AA(currentPly * SIZE + nextPly) = Internal.AA((currentPly + 1) * SIZE + nextPly);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool PlyInitialized(int currentPly, int nextPly) => nextPly < Length.AA(currentPly + 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UpdateLength(int ply) => Length.AA(ply) = Length.AA(ply + 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Count() => Length.AA(0);
+
+    public ref OrderedMoveEntry Get(int plyIndex) => ref Internal.AA(plyIndex);
+
+}

--- a/Backend/Data/Struct/OrderedMoveEntry.cs
+++ b/Backend/Data/Struct/OrderedMoveEntry.cs
@@ -1,9 +1,21 @@
-﻿using Backend.Data.Enum;
+﻿using System.Runtime.CompilerServices;
+using Backend.Data.Enum;
 
 namespace Backend.Data.Struct;
 
+#pragma warning disable CS0660, CS0661
 public struct OrderedMoveEntry
+#pragma warning restore CS0660, CS0661
 {
+
+    public static readonly OrderedMoveEntry Default = new(Square.Na, Square.Na, Promotion.None);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(OrderedMoveEntry first, OrderedMoveEntry second) =>
+        first.From == second.From && first.To == second.To && first.Promotion == second.Promotion;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(OrderedMoveEntry first, OrderedMoveEntry second) => !(first == second);
 
     public readonly Square From = Square.Na;
     public readonly Square To = Square.Na;

--- a/Backend/Data/Struct/SearchedMove.cs
+++ b/Backend/Data/Struct/SearchedMove.cs
@@ -22,13 +22,6 @@ public readonly struct SearchedMove
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator !=(OrderedMoveEntry entry, SearchedMove searchedMove) => !(entry == searchedMove);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator ==(SearchedMove first, SearchedMove second) =>
-        first.From == second.From && first.To == second.To && first.Promotion == second.Promotion;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator !=(SearchedMove first, SearchedMove second) => !(first == second);
-
     public SearchedMove(ref OrderedMoveEntry move, int evaluation)
     {
         From = move.From;

--- a/Backend/Version.cs
+++ b/Backend/Version.cs
@@ -5,7 +5,7 @@ namespace Backend;
 public static class Version
 {
 
-    private const string VERSION = "2.0.0.6";
+    private const string VERSION = "2.0.0.7";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Get()

--- a/Terminal/OperationCycle.cs
+++ b/Terminal/OperationCycle.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Backend;
 using Backend.Data;
 using Backend.Data.Enum;
 using Backend.Data.Struct;
@@ -31,7 +30,7 @@ internal static class OperationCycle
             if (againstSn && Enum.Parse<PieceColor>(colorToMove, true) == snColor) {
                 MoveSearch moveSearch = new(board, Table, new TimeControl(999999));
                 Console.WriteLine("Searching best move...");
-                SearchedMove bestMove = moveSearch.SearchAndReturn(8);
+                OrderedMoveEntry bestMove = moveSearch.SearchAndReturn(8);
                 from = bestMove.From;
                 to = bestMove.To;
                 promotion = bestMove.Promotion;

--- a/Terminal/Program.cs
+++ b/Terminal/Program.cs
@@ -93,7 +93,7 @@ internal static class Program
             for (int i = 1; i < depth + 1; i++) {
                 Stopwatch sw = new();
                 sw.Start();
-                SearchedMove bestMove = moveSearch.SearchAndReturn(i);
+                OrderedMoveEntry bestMove = moveSearch.SearchAndReturn(i);
                 sw.Stop();
                 
                 Console.Write(i + ": " + (bestMove.From.ToString() + bestMove.To).ToLower());
@@ -101,7 +101,6 @@ internal static class Program
                     Console.Write("=" + bestMove.Promotion.ToString()[0]);
                 }
                 
-                Console.Write(" [" + bestMove.Evaluation + "]");
                 Console.WriteLine(" (" + sw.ElapsedMilliseconds + " ms)");
             }
             

--- a/Terminal/UniversalChessInterface.cs
+++ b/Terminal/UniversalChessInterface.cs
@@ -165,7 +165,7 @@ public static class UniversalChessInterface
         if (args.Length == 1) return;
 
         TaskFactory factory = new();
-        SearchedMove bestMove;
+        OrderedMoveEntry bestMove;
         
         ActiveTimeControl = new TimeControl(3500);
         int maxDepth = 999;


### PR DESCRIPTION
This allows viewing what the engine expects in later moves (essentially, what the engine thinks the best future moves are).

The error bar is too high to consider this PR as ELO Gaining (especially since it's cosmetical mostly), however with some consideration and confidence, one can say it isn't ELO Losing.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
Score of StockNemo Dev vs StockNemo 2.0.0.5: 68 - 62 - 70 [0.515]
...      StockNemo Dev playing White: 41 - 25 - 34  [0.580] 100
...      StockNemo Dev playing Black: 27 - 37 - 36  [0.450] 100
...      White vs Black: 78 - 52 - 70  [0.565] 200
Elo difference: 10.4 +/- 38.9, LOS: 70.1 %, DrawRatio: 35.0 %
200 of 200 games finished.
```