### PR TITLE
Implement Razoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 **/.idea/**/dynamic.xml
 
 Lichess/config.yml
+EloSprt/
 
 # Rider
 # Rider auto-generates .iml files, and contentModel.xml

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -22,7 +22,7 @@ public class MoveSearch
     private const int ASPIRATION_DELTA = 30;
     private const int ASPIRATION_DEPTH = 4;
 
-    private const int RAZORING_EVALUATION_THRESHOLD = 150;
+    private const int RAZORING_EVALUATION_THRESHOLD = 640;
 
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
@@ -261,7 +261,7 @@ public class MoveSearch
         Square kingSq = board.KingLoc(board.ColorToMove);
         bool inCheck = MoveList.UnderAttack(board, kingSq, oppositeColor);
         
-        if (!inCheck && notRootNode) {
+        if (!inCheck) {
             // We should use the evaluation from our transposition table if we had a hit.
             // As that evaluation isn't truly static and may have been from a previous deep search.
             int positionalEvaluation = transpositionHit ? 
@@ -283,7 +283,7 @@ public class MoveSearch
             // Reduction depth for null move pruning.
             int reductionDepth = depth - NULL_MOVE_REDUCTION;
         
-            if (depth > NULL_MOVE_DEPTH) {
+            if (notRootNode && depth > NULL_MOVE_DEPTH) {
                 // For null move pruning, we give the turn to the opponent and let them make the move.
                 RevertNullMove rv = board.NullMove();
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -22,7 +22,7 @@ public class MoveSearch
     private const int ASPIRATION_DELTA = 30;
     private const int ASPIRATION_DEPTH = 4;
 
-    private const int RAZORING_EVALUATION_THRESHOLD = 640;
+    private const int RAZORING_EVALUATION_THRESHOLD = 200;
 
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -22,7 +22,7 @@ public class MoveSearch
     private const int ASPIRATION_DELTA = 30;
     private const int ASPIRATION_DEPTH = 4;
 
-    private const int RAZORING_EVALUATION_THRESHOLD = 450;
+    private const int RAZORING_EVALUATION_THRESHOLD = 150;
 
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -22,7 +22,7 @@ public class MoveSearch
     private const int ASPIRATION_DELTA = 30;
     private const int ASPIRATION_DEPTH = 4;
 
-    private const int RAZORING_EVALUATION_THRESHOLD = 200;
+    private const int RAZORING_EVALUATION_THRESHOLD = 450;
 
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;

--- a/Backend/Version.cs
+++ b/Backend/Version.cs
@@ -5,7 +5,7 @@ namespace Backend;
 public static class Version
 {
 
-    private const string VERSION = "2.0.0.7";
+    private const string VERSION = "2.0.0.8";
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string Get()

--- a/Terminal/UniversalChessInterface.cs
+++ b/Terminal/UniversalChessInterface.cs
@@ -73,11 +73,7 @@ public static class UniversalChessInterface
     private static void HandleIsReady(string input)
     {
         if (!input.ToLower().Equals("isready")) return;
-        Task.Run(() =>
-        {
-            while (Busy) {}
-            Console.WriteLine("readyok");
-        });
+        Console.WriteLine("readyok");
     }
 
     private static void HandleQuit(Thread thread, string input)


### PR DESCRIPTION
Razoring works on the assumption that if the static evaluation (with some threshold) is below alpha, then the opponent will be able to find at least one good move to improve their position. Thus, it makes no point to continue generating moves, and it is better to jump into QSearch.

## ELO Difference
### TC: 8s + 0.08s
Using `UHO_XXL_+0.90_+1.19.epd` and `RAZORING_EVALUATION_THRESHOLD = 150`:
```
Score of StockNemo 2.0.0.8-f0a66ecd vs StockNemo 2.0.0.7: 3339 - 3134 - 3524  [0.510] 9997
...      StockNemo 2.0.0.8-f0a66ecd playing White: 2027 - 1226 - 1748  [0.580] 5001
...      StockNemo 2.0.0.8-f0a66ecd playing Black: 1312 - 1908 - 1776  [0.440] 4996
...      White vs Black: 3935 - 2538 - 3524  [0.570] 9997
Elo difference: 7.1 +/- 5.5, LOS: 99.5 %, DrawRatio: 35.3 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```