### PR TITLE
Adding bishop pair bonus in evaluation

### DIFF
--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using Backend.Data;
 using Backend.Data.Enum;
 using Backend.Data.Struct;
@@ -10,6 +11,7 @@ public static class Evaluation
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();
+    public static readonly EvaluationStack ES = new();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int RelativeEvaluation(Board board)
@@ -30,8 +32,19 @@ public static class Evaluation
         phase = 24 - phase;
         phase = (phase * 256 + 24 / 2) / 24;
 
-        return (board.MaterialDevelopmentEvaluationEarly * (256 - phase) + 
-                board.MaterialDevelopmentEvaluationLate * phase) / 256;
+        return (EarlyGameEvaluation(board) * (256 - phase) + LateGameEvaluation(board) * phase) / 256;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int EarlyGameEvaluation(Board board)
+    {
+        return board.MaterialDevelopmentEvaluationEarly + (ES.WhiteBishops/2) * 40 - (ES.BlackBishops/2) * 40; 
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int LateGameEvaluation(Board board)
+    {
+        return board.MaterialDevelopmentEvaluationLate + (ES.WhiteBishops/2) * 60 - (ES.BlackBishops/2) * 60; 
     }
     
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/Backend/Engine/EvaluationStack.cs
+++ b/Backend/Engine/EvaluationStack.cs
@@ -1,0 +1,27 @@
+﻿using Backend.Data.Enum;
+
+namespace Backend.Data.Struct;
+
+public struct EvaluationStack
+{
+    public int WhiteRooks;
+    public int WhiteKnights;
+    public int WhiteBishops;
+    public int WhiteQueens;
+    public int BlackRooks;
+    public int BlackKnights;
+    public int BlackBishops;
+    public int BlackQueens;
+
+    public EvaluationStack(Board board)
+    {
+        WhiteRooks = board.All(Piece.Rook, PieceColor.White).Count;
+        WhiteKnights = board.All(Piece.Knight, PieceColor.White).Count;
+        WhiteBishops = board.All(Piece.Bishop, PieceColor.White).Count;
+        WhiteQueens = board.All(Piece.Queen, PieceColor.White).Count;
+        BlackRooks = board.All(Piece.Rook, PieceColor.Black).Count;
+        BlackKnights = board.All(Piece.Knight, PieceColor.Black).Count;
+        BlackBishops = board.All(Piece.Bishop, PieceColor.Black).Count;
+        BlackQueens = board.All(Piece.Queen, PieceColor.Black).Count;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StockNemo
-A Chess Engine written in C# trying to find good moves like Stockfish.
+A Chess Engine written in C# by TheBlackPlague trying to find good moves like Stockfish.
+
+Currently trying to fiddle with the evaluation for rating gain.
 
 Play vs StockNemo on <a href="https://lichess.org/?user=StockNemo#friend">Lichess!</a> 
 


### PR DESCRIPTION
With early comp = 30 and late comp = 50 cp respectively, engine performs ~+20 elo. 