### PR TITLE
Fix incorrect mapping from Promotion to Piece.

### DIFF
--- a/Backend/Data/Enum/Promotion.cs
+++ b/Backend/Data/Enum/Promotion.cs
@@ -4,9 +4,9 @@ public enum Promotion : byte
 {
 
     None,
-    Knight,
-    Bishop,
-    Rook,
-    Queen
+    Knight = 2,
+    Bishop = 3,
+    Rook = 1,
+    Queen = 4
 
 }


### PR DESCRIPTION
https://github.com/TheBlackPlague/StockNemo/blob/246e9ef1d5a6a33c59a622ad194df8c9bb37e5cf/Backend/Board.cs#L143-L147

When handling promotion in `Board::Move(Square from, Square to, Promotion promotion)`, the above code is run. This code just casts the `Promotion` enum to a `Piece` enum. 

However, the casting was all messed up as the bytes that corresponded to them were evidently different. This PR aims to fix that.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 14.24 +- 8.18 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4344 W: 1451 L: 1273 D: 1620
```