### PR TITLE
Implement bonuses in evaluation for having a Bishop Pair.

### DIFF
--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -8,8 +8,8 @@ namespace Backend.Engine;
 public static class Evaluation
 {
 
-    private const int BISHOP_PAIR_EARLY = 24;
-    private const int BISHOP_PAIR_LATE = 58;
+    private const int BISHOP_PAIR_EARLY = 25;
+    private const int BISHOP_PAIR_LATE = 50;
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();

--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -8,8 +8,8 @@ namespace Backend.Engine;
 public static class Evaluation
 {
 
-    private const int BISHOP_PAIR_EARLY = 35;
-    private const int BISHOP_PAIR_LATE = 70;
+    private const int BISHOP_PAIR_EARLY = 25;
+    private const int BISHOP_PAIR_LATE = 50;
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();

--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -7,6 +7,9 @@ namespace Backend.Engine;
 
 public static class Evaluation
 {
+
+    private const int BISHOP_PAIR_EARLY = 50;
+    private const int BISHOP_PAIR_LATE = 80;
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();
@@ -20,18 +23,33 @@ public static class Evaluation
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int NormalEvaluation(Board board)
     {
+        int earlyGameEvaluation = board.MaterialDevelopmentEvaluationEarly;
+        int lateGameEvaluation = board.MaterialDevelopmentEvaluationLate;
+        
         int phase = 0;
+
+        int whiteBishopCount = board.All(Piece.Bishop, PieceColor.White).Count;
+        int blackBishopCount = board.All(Piece.Bishop, PieceColor.Black).Count;
         
         phase += board.All(Piece.Knight, PieceColor.White).Count + board.All(Piece.Knight, PieceColor.Black).Count;
-        phase += board.All(Piece.Bishop, PieceColor.White).Count + board.All(Piece.Bishop, PieceColor.Black).Count;
+        phase += whiteBishopCount + blackBishopCount;
         phase += (board.All(Piece.Rook, PieceColor.White).Count + board.All(Piece.Rook, PieceColor.Black).Count) * 2;
         phase += (board.All(Piece.Queen, PieceColor.White).Count + board.All(Piece.Queen, PieceColor.Black).Count) * 4;
+
+        if (whiteBishopCount > 1) {
+            earlyGameEvaluation += BISHOP_PAIR_EARLY;
+            lateGameEvaluation += BISHOP_PAIR_LATE;
+        }
+
+        if (blackBishopCount > 1) {
+            earlyGameEvaluation -= BISHOP_PAIR_EARLY;
+            lateGameEvaluation -= BISHOP_PAIR_LATE;
+        }
 
         phase = 24 - phase;
         phase = (phase * 256 + 24 / 2) / 24;
 
-        return (board.MaterialDevelopmentEvaluationEarly * (256 - phase) + 
-                board.MaterialDevelopmentEvaluationLate * phase) / 256;
+        return (earlyGameEvaluation * (256 - phase) + lateGameEvaluation * phase) / 256;
     }
     
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -36,15 +36,8 @@ public static class Evaluation
         phase += (board.All(Piece.Rook, PieceColor.White).Count + board.All(Piece.Rook, PieceColor.Black).Count) * 2;
         phase += (board.All(Piece.Queen, PieceColor.White).Count + board.All(Piece.Queen, PieceColor.Black).Count) * 4;
 
-        if (whiteBishopCount > 1) {
-            earlyGameEvaluation += BISHOP_PAIR_EARLY;
-            lateGameEvaluation += BISHOP_PAIR_LATE;
-        }
-
-        if (blackBishopCount > 1) {
-            earlyGameEvaluation -= BISHOP_PAIR_EARLY;
-            lateGameEvaluation -= BISHOP_PAIR_LATE;
-        }
+        earlyGameEvaluation += ((whiteBishopCount >> 1) - (blackBishopCount >> 1)) * BISHOP_PAIR_EARLY;
+        lateGameEvaluation += ((whiteBishopCount >> 1) - (blackBishopCount >> 1)) * BISHOP_PAIR_LATE;
 
         phase = 24 - phase;
         phase = (phase * 256 + 24 / 2) / 24;

--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -8,8 +8,8 @@ namespace Backend.Engine;
 public static class Evaluation
 {
 
-    private const int BISHOP_PAIR_EARLY = 50;
-    private const int BISHOP_PAIR_LATE = 80;
+    private const int BISHOP_PAIR_EARLY = 35;
+    private const int BISHOP_PAIR_LATE = 70;
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();

--- a/Backend/Engine/Evaluation.cs
+++ b/Backend/Engine/Evaluation.cs
@@ -8,8 +8,8 @@ namespace Backend.Engine;
 public static class Evaluation
 {
 
-    private const int BISHOP_PAIR_EARLY = 25;
-    private const int BISHOP_PAIR_LATE = 50;
+    private const int BISHOP_PAIR_EARLY = 24;
+    private const int BISHOP_PAIR_LATE = 58;
     
     // ReSharper disable once InconsistentNaming
     public static readonly MaterialDevelopmentTable MDT = new();


### PR DESCRIPTION
## Idea

Bishops start at different color squares. Thus, having a pair generally allows for greater control of the square. Furthermore, with the pawns off the board in the late game, they typically control much more than a bishop and knight.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 6.02 +- 4.64 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14208 W: 4828 L: 4582 D: 4798
```