### PR TITLE
Implement Reverse Futility Pruning.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -30,9 +30,8 @@ public class MoveSearch
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
 
-    private const int REVERSE_FUTILITY_D = 67;
-    private const int REVERSE_FUTILITY_I = 76;
-    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 7;
+    private const int REVERSE_FUTILITY_K = 80;
+    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 8;
 
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 
@@ -292,9 +291,9 @@ public class MoveSearch
 
             #region Reverse Futility Pruning
 
-            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE &&
-                positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta) 
-                return beta;
+            if (depth <= REVERSE_FUTILITY_DEPTH_THRESHOLD && positionalEvaluation < MATE &&
+                positionalEvaluation - REVERSE_FUTILITY_K * (depth - improving.ToByte()) >= beta) 
+                return positionalEvaluation;
 
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -30,9 +30,9 @@ public class MoveSearch
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
 
-    private const int REVERSE_FUTILITY_D = 67;
-    private const int REVERSE_FUTILITY_I = 76;
-    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 7;
+    private const int REVERSE_FUTILITY_D = 70;
+    private const int REVERSE_FUTILITY_I = 80;
+    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 8;
 
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -30,8 +30,9 @@ public class MoveSearch
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
 
-    private const int REVERSE_FUTILITY_K = 80;
-    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 8;
+    private const int REVERSE_FUTILITY_D = 67;
+    private const int REVERSE_FUTILITY_I = 76;
+    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 7;
 
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 
@@ -291,9 +292,9 @@ public class MoveSearch
 
             #region Reverse Futility Pruning
 
-            if (depth <= REVERSE_FUTILITY_DEPTH_THRESHOLD && positionalEvaluation < MATE &&
-                positionalEvaluation - REVERSE_FUTILITY_K * (depth - improving.ToByte()) >= beta) 
-                return positionalEvaluation;
+            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE &&
+                positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta) 
+                return beta;
 
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -292,18 +292,17 @@ public class MoveSearch
 
             #region Reverse Futility Pruning
 
-            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE) {
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE &&
                 // If our depth is less than our threshold and our beta is less than mate on each end of the number
                 // line, then attempting reverse futility pruning is safe.
                 
-                // We calculate a positional evaluation with respect to our margin: D * depth + I * improving.
-                int marginedPositionalEvaluation = 
-                    positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte();
-                
-                // If our margined positional evaluation happens to be greater than beta, then we fail soft and return
-                // the margined positional evaluation.
-                if (marginedPositionalEvaluation >= beta) return marginedPositionalEvaluation;
-            }
+                // We calculate margined positional evaluation as the difference between the current positional
+                // evaluation and a margin: D * depth + I * improving.
+                // If it is greater or equal than beta, then in most cases than not, it is futile to further evaluate
+                // this tree and hence better to just return early.
+                positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta)
+                return beta;
 
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -30,9 +30,9 @@ public class MoveSearch
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
 
-    private const int REVERSE_FUTILITY_D = 70;
-    private const int REVERSE_FUTILITY_I = 80;
-    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 8;
+    private const int REVERSE_FUTILITY_D = 67;
+    private const int REVERSE_FUTILITY_I = 76;
+    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 7;
 
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -32,6 +32,7 @@ public class MoveSearch
 
     private const int REVERSE_FUTILITY_D = 67;
     private const int REVERSE_FUTILITY_I = 76;
+    private const int REVERSE_FUTILITY_DEPTH_THRESHOLD = 7;
 
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 
@@ -291,7 +292,7 @@ public class MoveSearch
 
             #region Reverse Futility Pruning
 
-            if (depth < 7 && Math.Abs(beta) < MATE &&
+            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE &&
                 positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta) 
                 return beta;
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -30,6 +30,9 @@ public class MoveSearch
     private const int NODE_COUNTING_DEPTH = 8;
     private const int NODE_COUNTING_REQUIRED_EFFORT = 95;
 
+    private const int REVERSE_FUTILITY_D = 67;
+    private const int REVERSE_FUTILITY_I = 76;
+
     private const float TIME_TO_DEPTH_THRESHOLD = 0.2f;
 
     public int TableCutoffCount { get; private set; }
@@ -289,7 +292,8 @@ public class MoveSearch
             #region Reverse Futility Pruning
 
             if (depth < 7 && Math.Abs(beta) < MATE &&
-                positionalEvaluation - 67 * depth + 76 * improving.ToByte() >= beta) return beta;
+                positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta) 
+                return beta;
 
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -292,9 +292,11 @@ public class MoveSearch
 
             #region Reverse Futility Pruning
 
-            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE &&
-                positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte() >= beta) 
-                return beta;
+            if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE) {
+                int marginedPositionalEvaluation = 
+                    positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte();
+                if (marginedPositionalEvaluation >= beta) return marginedPositionalEvaluation;
+            }
 
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -293,8 +293,15 @@ public class MoveSearch
             #region Reverse Futility Pruning
 
             if (depth < REVERSE_FUTILITY_DEPTH_THRESHOLD && Math.Abs(beta) < MATE) {
+                // If our depth is less than our threshold and our beta is less than mate on each end of the number
+                // line, then attempting reverse futility pruning is safe.
+                
+                // We calculate a positional evaluation with respect to our margin: D * depth + I * improving.
                 int marginedPositionalEvaluation = 
                     positionalEvaluation - REVERSE_FUTILITY_D * depth + REVERSE_FUTILITY_I * improving.ToByte();
+                
+                // If our margined positional evaluation happens to be greater than beta, then we fail soft and return
+                // the margined positional evaluation.
                 if (marginedPositionalEvaluation >= beta) return marginedPositionalEvaluation;
             }
 


### PR DESCRIPTION
In most cases, if we're already doing too good with a marginal advantage, it is futile to further evaluate the subset of the tree. In such cases, we can return early.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 96.61 +- 23.96 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 568 W: 263 L: 109 D: 196
```