### PR TITLE
Implement a Principle Variation Search.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -453,19 +453,27 @@ public class MoveSearch
             #region Principle Variation Search
             
             if (evaluation > alpha) {
-                // In the case that we cannot do LMR (being unsafe at this depth or for this move) or LMR fails, we
-                // should do a normal principle variation search. Thanks to transposition tables, this research is
-                // reasonably fast.
-                evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -alpha - 1, -alpha);
-
-                if (evaluation > alpha && evaluation < beta)
-                    // In the case that the evaluation is good enough to change our alpha, but not good enough to cause
-                    // a beta cutoff, it's likely we're on a principle variation node. In such a case, we should do a
-                    // full proper research. Thanks to transposition tables, this research is reasonably fast.
+                if (i == 0)
+                    // If we haven't searched any moves, we should do a full depth search.
                     
                     // Evaluate position by searching deeper and negating the result. An evaluation that's good for
                     // our opponent will obviously be bad for us.
                     evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -beta, -alpha);
+                else {
+                    // In the case that we cannot do LMR (being unsafe at this depth or for this move) or LMR fails, we
+                    // should do a normal principle variation search. Thanks to transposition tables, this research is
+                    // reasonably fast.
+                    evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -alpha - 1, -alpha);
+
+                    if (evaluation > alpha && evaluation < beta)
+                        // In the case that the evaluation is good enough to change our alpha, but not good enough to cause
+                        // a beta cutoff, it's likely we're on a principle variation node. In such a case, we should do a
+                        // full proper research. Thanks to transposition tables, this research is reasonably fast.
+                    
+                        // Evaluate position by searching deeper and negating the result. An evaluation that's good for
+                        // our opponent will obviously be bad for us.
+                        evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -beta, -alpha);
+                }
             }
             
             #endregion

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -458,7 +458,7 @@ public class MoveSearch
                 // reasonably fast.
                 evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -alpha - 1, -alpha);
 
-                if (pvNode && evaluation > alpha && evaluation < beta)
+                if (evaluation > alpha && evaluation < beta)
                     // In the case that the evaluation is good enough to change our alpha, but not good enough to cause
                     // a beta cutoff, it's likely we're on a principle variation node. In such a case, we should do a
                     // full proper research. Thanks to transposition tables, this research is reasonably fast.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -213,7 +213,7 @@ public class MoveSearch
 
         #endregion
 
-        bool pvNode = alpha - beta > 1;
+        bool pvNode = beta - alpha > 1;
 
         #region Transposition Table Lookup
 
@@ -458,7 +458,7 @@ public class MoveSearch
                 // reasonably fast.
                 evaluation = -AbSearch(board, nextPlyFromRoot, nextDepth, -alpha - 1, -alpha);
 
-                if (evaluation > alpha && evaluation < beta)
+                if (pvNode && evaluation > alpha && evaluation < beta)
                     // In the case that the evaluation is good enough to change our alpha, but not good enough to cause
                     // a beta cutoff, it's likely we're on a principle variation node. In such a case, we should do a
                     // full proper research. Thanks to transposition tables, this research is reasonably fast.


### PR DESCRIPTION
Currently, when searching for the best moves, once we find one that changes the alpha, we do not resize the upper window around it. With Principle Variation Search, we resize the upper bound too, and only in failure (**a move is better than alpha but worse than beta**) do we do a normal window research. 

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 10.65 +- 6.91 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6200 W: 2075 L: 1885 D: 2240
```