### PR TITLE
Hand tune Null Move Pruning constants.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -15,8 +15,8 @@ public class MoveSearch
     private const int NEG_INFINITY = -POS_INFINITY;
     private const int MATE = POS_INFINITY - 1;
 
-    private const int NULL_MOVE_REDUCTION = 6;
-    private const int NULL_MOVE_DEPTH = 14;
+    private const int NULL_MOVE_REDUCTION = 9;
+    private const int NULL_MOVE_DEPTH = 7;
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_DELTA = 30;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -15,8 +15,8 @@ public class MoveSearch
     private const int NEG_INFINITY = -POS_INFINITY;
     private const int MATE = POS_INFINITY - 1;
 
-    private const int NULL_MOVE_REDUCTION = 3;
-    private const int NULL_MOVE_DEPTH = NULL_MOVE_REDUCTION - 1;
+    private const int NULL_MOVE_REDUCTION = 6;
+    private const int NULL_MOVE_DEPTH = 14;
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_DELTA = 30;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -15,8 +15,8 @@ public class MoveSearch
     private const int NEG_INFINITY = -POS_INFINITY;
     private const int MATE = POS_INFINITY - 1;
 
-    private const int NULL_MOVE_REDUCTION = 8;
-    private const int NULL_MOVE_DEPTH = 6;
+    private const int NULL_MOVE_REDUCTION = 4;
+    private const int NULL_MOVE_DEPTH = 2;
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_DELTA = 30;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -15,8 +15,8 @@ public class MoveSearch
     private const int NEG_INFINITY = -POS_INFINITY;
     private const int MATE = POS_INFINITY - 1;
 
-    private const int NULL_MOVE_REDUCTION = 9;
-    private const int NULL_MOVE_DEPTH = 7;
+    private const int NULL_MOVE_REDUCTION = 8;
+    private const int NULL_MOVE_DEPTH = 6;
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_DELTA = 30;


### PR DESCRIPTION
While the original attempt was made to use Chess Tuning Tools, it seems that the tuning was not successful. That may be due to the tool not working as expected or the wrong configuration being used. It is unknown right now.

The optimum values suggested by Chess Tuning Tools were these compared to base values: 
```diff
- NULL_MOVE_REDUCTION = 3
- NULL_MOVE_DEPTH = NULL_MOVE_REDUCTION - 1
+ NULL_MOVE_REDUCTION = 6
+ NULL_MOVE_DEPTH = 14
```

However, from hand tuning, the actual ELO-gaining values were these compared to base values:
```diff
- NULL_MOVE_REDUCTION = 3
- NULL_MOVE_DEPTH = NULL_MOVE_REDUCTION - 1
+ NULL_MOVE_REDUCTION = 4
+ NULL_MOVE_DEPTH = 2
```

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:

Optimum (from CTT):
```
ELO   | -48.42 +- 16.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1040 W: 254 L: 398 D: 388
```

Hand Tuning:
```
ELO   | 13.98 +- 8.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4400 W: 1459 L: 1282 D: 1659
```