### PR TITLE
Speed up BitBoard Indexing.

### DIFF
--- a/Backend/Data/Struct/BitBoard.cs
+++ b/Backend/Data/Struct/BitBoard.cs
@@ -168,7 +168,11 @@ public struct BitBoard
     public bool this[Square sq]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (Internal >> (int)sq & 1UL) == 1UL;
+        get
+        {
+            byte value = (byte)(Internal >> (int)sq & 1UL);
+            return Unsafe.As<byte, bool>(ref value);
+        }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set
         {
@@ -180,7 +184,11 @@ public struct BitBoard
     public bool this[int i]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (Internal >> i & 1UL) == 1UL;
+        get
+        {
+            byte value = (byte)(Internal >> i & 1UL);
+            return Unsafe.As<byte, bool>(ref value);
+        }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set
         {


### PR DESCRIPTION
Currently, an equality operation is done against `1UL` to check if a bit is set in a BitBoard.

The generated assembly for this is not the best. See: https://github.com/dotnet/runtime/issues/72986

The new version uses a reinterpreted cast which is faster by avoiding the `test` instruction. Also see: https://github.com/dotnet/runtime/issues/72986

Given this is a clear performance improvement, there is no need for an ELO difference check.