### PR TITLE
Tune Aspiration Search with Chess Tuning Tools.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -19,8 +19,8 @@ public class MoveSearch
     private const int NULL_MOVE_DEPTH = 2;
 
     private const int ASPIRATION_BOUND = 3500;
-    private const int ASPIRATION_SIZE = 16;
-    private const int ASPIRATION_DELTA = 23;
+    private const int ASPIRATION_SIZE = 15;
+    private const int ASPIRATION_DELTA = 24;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -20,7 +20,7 @@ public class MoveSearch
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_SIZE = 15;
-    private const int ASPIRATION_DELTA = 24;
+    private const int ASPIRATION_DELTA = 20;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -19,8 +19,8 @@ public class MoveSearch
     private const int NULL_MOVE_DEPTH = 2;
 
     private const int ASPIRATION_BOUND = 3500;
-    private const int ASPIRATION_SIZE = 15;
-    private const int ASPIRATION_DELTA = 24;
+    private const int ASPIRATION_SIZE = 16;
+    private const int ASPIRATION_DELTA = 23;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -20,7 +20,7 @@ public class MoveSearch
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_SIZE = 15;
-    private const int ASPIRATION_DELTA = 20;
+    private const int ASPIRATION_DELTA = 24;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -20,7 +20,7 @@ public class MoveSearch
 
     private const int ASPIRATION_BOUND = 3500;
     private const int ASPIRATION_SIZE = 16;
-    private const int ASPIRATION_DELTA = 24;
+    private const int ASPIRATION_DELTA = 23;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -19,8 +19,8 @@ public class MoveSearch
     private const int NULL_MOVE_DEPTH = 2;
 
     private const int ASPIRATION_BOUND = 3500;
-    private const int ASPIRATION_SIZE = 50;
-    private const int ASPIRATION_DELTA = 30;
+    private const int ASPIRATION_SIZE = 16;
+    private const int ASPIRATION_DELTA = 24;
     private const int ASPIRATION_DEPTH = 4;
 
     private const int RAZORING_EVALUATION_THRESHOLD = 150;

--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ Stockfish Team for providing numerous insights and making a brilliant engine,
 used numerous times to debug StockNemo.
 - [OpenBench](https://github.com/AndyGrant/OpenBench) by Andrew Grant for making
 an amazing framework that allows distributed testing of StockNemo.
+- [Chess Tuning Tools](https://github.com/kiudee/chess-tuning-tools) by Karlson 
+Pfannschmidt for being an amazing utility software to tune StockNemo.


### PR DESCRIPTION
This tuning was done using [Chess Tuning Tools (CTT)](https://github.com/kiudee/chess-tuning-tools) by @kiudee. Multiple provided optimums were tested, but from the tuning, the following optimum worked best:
```
ASPIRATION_SIZE = 16;
ASPIRATION_DELTA = 23;
ASPIRATION_DEPTH = 4;
```

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 15.91 +- 8.69 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3672 W: 1181 L: 1013 D: 1478
```