### PR TITLE
Implement Check Extensions.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -346,7 +346,16 @@ public class MoveSearch
             }
 
             #endregion
-        } else if (inCheck) depth++;
+        } else if (inCheck) {
+            #region Check Extension
+
+            // If we're in check, then it's better to evaluate this position deeper as to get good idea of situation,
+            // avoiding unseen blunders. Due to the number of moves being very less when under check, one shouldn't
+            // be concerned about search explosion.
+            depth++;
+
+            #endregion
+        }
 
         #region Move List Creation
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -284,6 +284,7 @@ public class MoveSearch
         bool inCheck = MoveList.UnderAttack(board, kingSq, oppositeColor);
         bool improving = false;
         
+        // ReSharper disable once ConvertIfStatementToSwitchStatement
         if (!inCheck && !pvNode) {
             // We should use the evaluation from our transposition table if we had a hit.
             // As that evaluation isn't truly static and may have been from a previous deep search.
@@ -345,7 +346,7 @@ public class MoveSearch
             }
 
             #endregion
-        }
+        } else if (inCheck) depth++;
 
         #region Move List Creation
 


### PR DESCRIPTION
The idea behind check extensions is to increase the accuracy of our evaluation. Currently, StockNemo, while avoiding pruning whatsoever when under check, doesn't really push to get an accurate evaluation. The idea behind check extensions is that when under check, StockNemo will evaluate the tree deeper, making its overall move choice and evaluation much more accurate. Furthermore, since there is a limited number of moves when under check, it means one does not have to worry about search explosion. 

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 32.56 +- 12.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1648 W: 556 L: 402 D: 690
```