### PR TITLE
Update Best Move in Aspiration Search for Fail-High.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -74,7 +74,7 @@ public class MoveSearch
             Stopwatch stopwatch = Stopwatch.StartNew();
             bool timePreviouslyUpdated = false;
             while (!TimeControl.Finished() && depth <= selectedDepth) {
-                evaluation = AspirationSearch(Board, depth, evaluation);
+                evaluation = AspirationSearch(Board, depth, evaluation, ref bestMove);
                 bestMove = PvTable.Get(0);
 
                 // Try counting nodes to see if we can exit the search early.
@@ -95,7 +95,7 @@ public class MoveSearch
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int AspirationSearch(EngineBoard board, int depth, int previousEvaluation)
+    private int AspirationSearch(EngineBoard board, int depth, int previousEvaluation, ref OrderedMoveEntry bestMove)
     {
         // Set base window size.
         int alpha = NEG_INFINITY;
@@ -151,6 +151,9 @@ public class MoveSearch
                 // If our evaluation was somehow better than our beta, we should resize our window and research.
                 beta = Math.Min(beta + research * research * ASPIRATION_DELTA, POS_INFINITY);
                 
+                // Update our best move in case our evaluation was better than beta to get best possible move.
+                bestMove = PvTable.Get(0);
+
                 // If our evaluation was within our window, we should return the result avoiding any researches.
             } else return bestEvaluation;
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -151,7 +151,9 @@ public class MoveSearch
                 // If our evaluation was somehow better than our beta, we should resize our window and research.
                 beta = Math.Min(beta + research * research * ASPIRATION_DELTA, POS_INFINITY);
                 
-                // Update our best move in case our evaluation was better than beta to get best possible move.
+                // Update our best move in case our evaluation was better than beta.
+                // The move we get in future surely can't be worse than this so it's fine to update our best move
+                // directly on a beta cutoff.
                 bestMove = PvTable.Get(0);
 
                 // If our evaluation was within our window, we should return the result avoiding any researches.


### PR DESCRIPTION
The idea stems from the fact that if we fail high on a small window search, it's impossible that the next move will be worse. Hence, it's acceptable to set it as our best move so far and return that if we run out of time.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 17.28 +- 9.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3320 W: 1048 L: 883 D: 1389
```