### PR TITLE
Scale reduction depth for null move pruning linearly.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -333,7 +333,7 @@ public class MoveSearch
                 RevertNullMove rv = board.NullMove();
                 
                 // Reduction depth for null move pruning.
-                int reductionDepth = depth - (NULL_MOVE_REDUCTION + (depth >> 2));
+                int reductionDepth = depth - depth / 3;
                 
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
                 // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -338,7 +338,7 @@ public class MoveSearch
                 RevertNullMove rv = board.NullMove();
                 
                 // Reduction depth for null move pruning.
-                int reductionDepth = depth - depth / 3;
+                int reductionDepth = depth - NULL_MOVE_REDUCTION - (depth / 3 - 1);
                 
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
                 // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -327,13 +327,14 @@ public class MoveSearch
             #endregion
             
             #region Null Move Pruning
-
-            // Reduction depth for null move pruning.
-            int reductionDepth = depth - NULL_MOVE_REDUCTION;
         
             if (notRootNode && depth > NULL_MOVE_DEPTH) {
                 // For null move pruning, we give the turn to the opponent and let them make the move.
                 RevertNullMove rv = board.NullMove();
+                
+                // Reduction depth for null move pruning.
+                int reductionDepth = depth - NULL_MOVE_REDUCTION + depth >> 2;
+                
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
                 // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff
                 // this branch earlier.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -333,7 +333,7 @@ public class MoveSearch
                 RevertNullMove rv = board.NullMove();
                 
                 // Reduction depth for null move pruning.
-                int reductionDepth = depth - NULL_MOVE_REDUCTION + depth >> 2;
+                int reductionDepth = depth - NULL_MOVE_REDUCTION + (depth >> 2);
                 
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
                 // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -333,7 +333,7 @@ public class MoveSearch
                 RevertNullMove rv = board.NullMove();
                 
                 // Reduction depth for null move pruning.
-                int reductionDepth = depth - NULL_MOVE_REDUCTION + (depth >> 2);
+                int reductionDepth = depth - (NULL_MOVE_REDUCTION + (depth >> 2));
                 
                 // Then we evaluate position by searching at a reduced depth using same characteristics as normal search.
                 // The idea is that if there are cutoffs, most will be found using this reduced search and we can cutoff


### PR DESCRIPTION
The idea is that at higher depths, we should reduce the depth further than we do at shallow depths.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 5.99 +- 4.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13120 W: 3932 L: 3706 D: 5482
```