### PR TITLE
Refactor PieceColor API. 

### DIFF
--- a/Backend/Board.cs
+++ b/Backend/Board.cs
@@ -94,7 +94,7 @@ public class Board
         if (EnPassantTarget == to && pieceF == Piece.Pawn) {
             // If the attack is an EP attack, we must empty the piece affected by EP.
             Square epPieceSq = colorF == PieceColor.White ? EnPassantTarget - 8 : EnPassantTarget + 8;
-            PieceColor oppositeColor = Util.OppositeColor(colorF);
+            PieceColor oppositeColor = colorF.OppositeColor();
             Map.Empty(Piece.Pawn, oppositeColor, epPieceSq);
             
             Evaluation.NNUE.EfficientlyUpdateAccumulator(Piece.Pawn, oppositeColor, epPieceSq, false);
@@ -249,7 +249,7 @@ public class Board
         );
 
         // Flip the turn.
-        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Map.ColorToMove = Map.ColorToMove.OppositeColor();
         
         // Update Zobrist.
         Zobrist.FlipTurnInHash(ref Map.ZobristHash);
@@ -276,7 +276,7 @@ public class Board
         if (EnPassantTarget == to && pieceF == Piece.Pawn) {
             // If the attack is an EP attack, we must empty the piece affected by EP.
             Square epPieceSq = colorF == PieceColor.White ? EnPassantTarget - 8 : EnPassantTarget + 8;
-            PieceColor oppositeColor = Util.OppositeColor(colorF);
+            PieceColor oppositeColor = colorF.OppositeColor();
             Map.Empty(Piece.Pawn, oppositeColor, epPieceSq);
 
             // Set it in revert move.
@@ -421,7 +421,7 @@ public class Board
         );
 
         // Flip the turn.
-        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Map.ColorToMove = Map.ColorToMove.OppositeColor();
         
         // Update Zobrist.
         Zobrist.FlipTurnInHash(ref Map.ZobristHash);

--- a/Backend/Data/Enum/PieceColor.cs
+++ b/Backend/Data/Enum/PieceColor.cs
@@ -1,4 +1,6 @@
-﻿namespace Backend.Data.Enum;
+﻿using System.Runtime.CompilerServices;
+
+namespace Backend.Data.Enum;
 
 public enum PieceColor : byte
 {
@@ -8,5 +10,13 @@ public enum PieceColor : byte
     White,
     Black,
     None
+
+}
+
+public static class PieceColorUtil
+{
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PieceColor OppositeColor(this PieceColor color) => (PieceColor)((int)color ^ 0x1);
 
 }

--- a/Backend/Data/Struct/MoveList.cs
+++ b/Backend/Data/Struct/MoveList.cs
@@ -188,7 +188,7 @@ public ref struct MoveList
     public static MoveList WithoutProvidedPins(Board board, Square from)
     {
         (Piece piece, PieceColor color) = board.At(from);
-        PieceColor oppositeColor = Util.OppositeColor(color);
+        PieceColor oppositeColor = color.OppositeColor();
         
         Square kingSq = board.KingLoc(color);
         (BitBoard horizontalVertical, BitBoard diagonal) = PinBitBoards(board, kingSq, color, oppositeColor);
@@ -320,7 +320,7 @@ public ref struct MoveList
             return;
         }
         
-        PieceColor oppositeColor = Util.OppositeColor(color);
+        PieceColor oppositeColor = color.OppositeColor();
         BitBoard opposite = Board.All(oppositeColor);
         Square epPieceSq = Square.Na;
         
@@ -407,7 +407,7 @@ public ref struct MoveList
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private void LegalPawnMoveSet(PieceColor color)
     {
-        PieceColor oppositeColor = Util.OppositeColor(color);
+        PieceColor oppositeColor = color.OppositeColor();
         BitBoard from = From;
         BitBoard opposite = Board.All(oppositeColor);
         Square epPieceSq = Square.Na;
@@ -576,7 +576,7 @@ public ref struct MoveList
         // or not by removing the king.
         if (!kingMoves) return;
 
-        PieceColor oppositeColor = Util.OppositeColor(color);
+        PieceColor oppositeColor = color.OppositeColor();
         BitBoardIterator kingMovesIterator = kingMoves.GetEnumerator();
         Square move = kingMovesIterator.Current;
         Board.RemovePiece(Piece.King, color, From);

--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -90,7 +90,7 @@ public readonly ref struct OrderedMoveList
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public int NormalMoveGeneration(Board board, SearchedMove transpositionMove)
     {
-        PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        PieceColor oppositeColor = board.ColorToMove.OppositeColor();
 
         // Generate pins and check bitboards.
         Square kingSq = board.KingLoc(board.ColorToMove);
@@ -193,7 +193,7 @@ public readonly ref struct OrderedMoveList
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public int QSearchMoveGeneration(Board board, SearchedMove transpositionMove)
     {
-        PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        PieceColor oppositeColor = board.ColorToMove.OppositeColor();
         // If we only want capture moves, we should also define our opposite board.
         BitBoard opposite = board.All(oppositeColor);
 

--- a/Backend/Engine/EngineBoard.cs
+++ b/Backend/Engine/EngineBoard.cs
@@ -47,7 +47,7 @@ public class EngineBoard : Board
         if (Map.EnPassantTarget != Square.Na) Zobrist.HashEp(ref Map.ZobristHash, Map.EnPassantTarget);
         Map.EnPassantTarget = Square.Na;
 
-        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Map.ColorToMove = Map.ColorToMove.OppositeColor();
         Zobrist.FlipTurnInHash(ref Map.ZobristHash);
 
         return rv;
@@ -61,7 +61,7 @@ public class EngineBoard : Board
             Zobrist.HashEp(ref Map.ZobristHash, rv.EnPassantTarget);
         }
 
-        Map.ColorToMove = Util.OppositeColor(Map.ColorToMove);
+        Map.ColorToMove = Map.ColorToMove.OppositeColor();
         Zobrist.FlipTurnInHash(ref Map.ZobristHash);
     }
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -286,7 +286,7 @@ public class MoveSearch
         int nextPlyFromRoot = plyFromRoot + 1;
 
         // Determine whether we should prune moves.
-        PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        PieceColor oppositeColor = board.ColorToMove.OppositeColor();
         Square kingSq = board.KingLoc(board.ColorToMove);
         bool inCheck = MoveList.UnderAttack(board, kingSq, oppositeColor);
         bool improving = false;

--- a/Backend/Engine/NNUE/Architecture/Basic/BasicNNUE.cs
+++ b/Backend/Engine/NNUE/Architecture/Basic/BasicNNUE.cs
@@ -86,7 +86,7 @@ public class BasicNNUE
 
             sq = blackIterator.Current;
             while (blackIterator.MoveNext()) {
-                int index = (int)Util.OppositeColor(color) * colorStride + (int)piece * pieceStride + ((int)sq ^ 56);
+                int index = (int)color.OppositeColor() * colorStride + (int)piece * pieceStride + ((int)sq ^ 56);
                 BlackPOV.AA(index) = 1;
                 sq = blackIterator.Current;
             }
@@ -110,7 +110,7 @@ public class BasicNNUE
         int opPieceStride = (int)nnPiece * pieceStride;
 
         int whiteIndex = (int)color * colorStride + opPieceStride + (int)sq;
-        int blackIndex = (int)Util.OppositeColor(color) * colorStride + opPieceStride + ((int)sq ^ 56);
+        int blackIndex = (int)color.OppositeColor() * colorStride + opPieceStride + ((int)sq ^ 56);
 
         BasicAccumulator<short> accumulator = Accumulators.AA(CurrentAccumulator);
 

--- a/Backend/Engine/TimeControl.cs
+++ b/Backend/Engine/TimeControl.cs
@@ -39,7 +39,7 @@ public class TimeControl
 
         // ReSharper disable once InvertIf
         if (moveCount >= DELTA_MOVE_BOUND) {
-            int dTime = timeForColor[(int)colorToMove] - timeForColor[(int)Util.OppositeColor(colorToMove)];
+            int dTime = timeForColor[(int)colorToMove] - timeForColor[(int)colorToMove.OppositeColor()];
             if (dTime >= DELTA_THRESHOLD) Time += dTime / DELTA_DIV;
         }
         

--- a/Backend/Perft.cs
+++ b/Backend/Perft.cs
@@ -86,7 +86,7 @@ public class Perft
         ulong count = 0;
 
         // Figure out color and opposite color from the one set in the board.
-        PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        PieceColor oppositeColor = board.ColorToMove.OppositeColor();
 
         // Get all squares occupied by our color.
         BitBoard colored = board.All(board.ColorToMove);
@@ -259,7 +259,7 @@ public class Perft
         ulong count = 0;
 
         // Figure out color and opposite color from the one set in the board.
-        PieceColor oppositeColor = Util.OppositeColor(board.ColorToMove);
+        PieceColor oppositeColor = board.ColorToMove.OppositeColor();
 
         // Get all squares occupied by our color.
         BitBoard colored = board.All(board.ColorToMove);

--- a/Backend/Util.cs
+++ b/Backend/Util.cs
@@ -29,9 +29,6 @@ public static class Util
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static PieceColor OppositeColor(PieceColor color) => (PieceColor)((int)color ^ 0x1);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // ReSharper disable once InconsistentNaming
     public static ref T AA<T>(this T[] array, int index)
     {

--- a/Terminal/Interactive/InteractiveInterface.cs
+++ b/Terminal/Interactive/InteractiveInterface.cs
@@ -146,7 +146,7 @@ internal static class InteractiveInterface
             }
 
             // If we're attacking opponent's king, then the opponent is under check.
-            PieceColor attackingColor = Util.OppositeColor(Board.ColorToMove);
+            PieceColor attackingColor = Board.ColorToMove.OppositeColor();
             if (MoveList.UnderAttack(Board, Board.KingLoc(Board.ColorToMove), attackingColor)) Check = true;
         }
     }
@@ -201,7 +201,7 @@ internal static class InteractiveInterface
     {
         DrawCycle.Draw(Board);
         if (Check) Console.WriteLine(Board.ColorToMove + " is under check.");
-        if (CheckMate) Console.WriteLine("Checkmate - " + Util.OppositeColor(Board.ColorToMove) + " won!");
+        if (CheckMate) Console.WriteLine("Checkmate - " + Board.ColorToMove.OppositeColor() + " won!");
     }
 
 }


### PR DESCRIPTION
Currently, a method known as `Util.OppositeColor(PieceColor)` exists. It's better to refactor this into the PieceColor enum instead. Gives the code a cleaner look.

Due to the nature of this PR and all unit tests passing, it doesn't need to be ELO tested.