### PR TITLE
Implement Futility Pruning.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -445,8 +445,7 @@ public class MoveSearch
         int i = 0;
         int quietMoveCounter = 0;
         int lmpQuietThreshold = LMP_QUIET_THRESHOLD_BASE + depth * depth;
-        bool fp = notRootNode && !inCheck && !pvNode;
-        bool lmp = fp && depth <= LMP_DEPTH_THRESHOLD;
+        bool lmp = notRootNode && !inCheck && !pvNode && depth <= LMP_DEPTH_THRESHOLD;
         bool lmr = depth >= LMR_DEPTH_THRESHOLD && !inCheck;
         while (i < moveCount) {
             // We should being the move that's likely to be the best move at this depth to the top. This ensures
@@ -462,7 +461,7 @@ public class MoveSearch
 
             #region Futility Pruning
 
-            if (fp && i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 
+            if (i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 
                 // If our move is a quiet and static evaluation of a position with a depth-relative margin is below
                 // our alpha, then the move won't really help us improve our position. And nor will any future move.
                 // Hence, it's futile to evaluate this position any further.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -445,7 +445,8 @@ public class MoveSearch
         int i = 0;
         int quietMoveCounter = 0;
         int lmpQuietThreshold = LMP_QUIET_THRESHOLD_BASE + depth * depth;
-        bool lmp = notRootNode && !inCheck && !pvNode && depth <= LMP_DEPTH_THRESHOLD;
+        bool fp = notRootNode && !inCheck && !pvNode;
+        bool lmp = fp && depth <= LMP_DEPTH_THRESHOLD;
         bool lmr = depth >= LMR_DEPTH_THRESHOLD && !inCheck;
         while (i < moveCount) {
             // We should being the move that's likely to be the best move at this depth to the top. This ensures
@@ -461,7 +462,7 @@ public class MoveSearch
 
             #region Futility Pruning
 
-            if (i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 
+            if (fp && i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 
                 // If our move is a quiet and static evaluation of a position with a depth-relative margin is below
                 // our alpha, then the move won't really help us improve our position. And nor will any future move.
                 // Hence, it's futile to evaluate this position any further.


### PR DESCRIPTION
The idea stems from the fact that if the static evaluation of a position with some depth-dependent margin isn't greater than alpha,  then quiet moves have no chance of improving the position further, making it futile to evaluate it further.

## ELO Difference
### TC: 10s + 0.1s
Using `UHO_XXL_+0.90_+1.19.epd`:
```
ELO   | 12.89 +- 7.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4664 W: 1413 L: 1240 D: 2011
```