### PR TITLE
Use Transposition Table in QSearch.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -611,6 +611,25 @@ public class MoveSearch
         if (typeof(Node) == typeof(PvNode)) SelectiveDepth = Math.Max(SelectiveDepth, plyFromRoot);
 
         #endregion
+
+        #region Transposition Table Lookup
+
+        if (typeof(Node) == typeof(NonPvNode)) {
+            ref MoveTranspositionTableEntry storedEntry = ref Table[board.ZobristHash];
+            if (storedEntry.Type != MoveTranspositionTableEntryType.Invalid && 
+                storedEntry.ZobristHash == board.ZobristHash) {
+                // Depending on the type of entry and our alpha and beta, we can return earlier.
+                if (storedEntry.Type == MoveTranspositionTableEntryType.Exact ||
+                    storedEntry.Type == MoveTranspositionTableEntryType.BetaCutoff &&
+                    storedEntry.BestMove.Evaluation >= beta ||
+                    storedEntry.Type == MoveTranspositionTableEntryType.AlphaUnchanged &&
+                    storedEntry.BestMove.Evaluation <= alpha) {
+                    return storedEntry.BestMove.Evaluation;
+                }
+            }
+        }
+
+        #endregion
         
         #region Early Evaluation
         

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -666,27 +666,21 @@ public class MoveSearch
         #region Fail-soft Alpha Beta Negamax
         
         int bestEvaluation = earlyEval;
-        OrderedMoveEntry bestMoveSoFar = new(Square.Na, Square.Na, Promotion.None);
-        MoveTranspositionTableEntryType transpositionTableEntryType = MoveTranspositionTableEntryType.AlphaUnchanged;
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        bool HandleEvaluation(int evaluation, ref OrderedMoveEntry move)
+        bool HandleEvaluation(int evaluation)
         {
             if (evaluation <= bestEvaluation) return true;
             
             // If our evaluation was better than our current best evaluation, we should update our evaluation
-            // with the new evaluation. We should also take into account that it was our best move so far.
+            // with the new evaluation.
             bestEvaluation = evaluation;
-            bestMoveSoFar = move;
 
             if (evaluation <= alpha) return true;
 
             // If our evaluation was better than our alpha (best unavoidable evaluation so far), then we should
             // replace our alpha with our evaluation.
             alpha = evaluation;
-            
-            // Our alpha changed, so it is no longer an unchanged alpha entry.
-            transpositionTableEntryType = MoveTranspositionTableEntryType.Exact;
             
             // If the evaluation was better than beta, it means the position was too good. Thus, there
             // is a good chance that the opponent will avoid this path. Hence, there is currently no
@@ -716,23 +710,11 @@ public class MoveSearch
             // Undo the move.
             board.UndoMove(ref rv);
 
-            if (!HandleEvaluation(evaluation, ref move)) {
-                // We had a beta cutoff, hence it's a beta cutoff entry.
-                transpositionTableEntryType = MoveTranspositionTableEntryType.BetaCutoff;
-                break;
-            }
+            if (!HandleEvaluation(evaluation)) break;
             
             i++;
         }
         
-        #endregion
-        
-        #region Transposition Table Insertion
-        
-        SearchedMove bestMove = new(ref bestMoveSoFar, bestEvaluation);
-        MoveTranspositionTableEntry entry = new(board.ZobristHash, transpositionTableEntryType, bestMove, 0);
-        Table.InsertEntry(board.ZobristHash, ref entry);
-
         #endregion
         
         return bestEvaluation;


### PR DESCRIPTION
This PR implements the necessary functionality to use the Transposition Table in QSearch. Currently, it's in a read-only fashion. 

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 6.53 +- 4.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10856 W: 3098 L: 2894 D: 4864
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 10.73 +- 6.65 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5504 W: 1532 L: 1362 D: 2610
```