### PR TITLE
Implement Approximated Static Exchange Evaluation in QSearch.

### DIFF
--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Backend.Data.Enum;
-using Backend.Engine;
 
 namespace Backend.Data.Struct;
 
@@ -33,7 +32,7 @@ public readonly ref struct OrderedMoveList
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ScoreMove(
         Piece pieceToMove,
-        EngineBoard board, 
+        Board board, 
         ref OrderedMoveEntry move,
         SearchedMove tableMove
         )
@@ -56,8 +55,7 @@ public readonly ref struct OrderedMoveList
         // The idea behind it is to give highest priority to captures that are capturing most valuable pieces
         // with least valuable pieces.
         Piece to = board.At(move.To).Item1;
-        if (to != Piece.Empty) return MvvLva(board.At(move.From).Item1, to) * 10000 + 
-                                      SEE.Approximate(board, ref move);
+        if (to != Piece.Empty) return MvvLva(board.At(move.From).Item1, to) * 10000;
 
         // If the move is a quiet move (not capture / promotion), then we should check if it is a killer move or history
         // move.
@@ -90,7 +88,7 @@ public readonly ref struct OrderedMoveList
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    public int NormalMoveGeneration(EngineBoard board, SearchedMove transpositionMove)
+    public int NormalMoveGeneration(Board board, SearchedMove transpositionMove)
     {
         PieceColor oppositeColor = board.ColorToMove.OppositeColor();
 
@@ -193,7 +191,7 @@ public readonly ref struct OrderedMoveList
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    public int QSearchMoveGeneration(EngineBoard board, SearchedMove transpositionMove)
+    public int QSearchMoveGeneration(Board board, SearchedMove transpositionMove)
     {
         PieceColor oppositeColor = board.ColorToMove.OppositeColor();
         // If we only want capture moves, we should also define our opposite board.

--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using Backend.Data.Enum;
+using Backend.Engine;
 
 namespace Backend.Data.Struct;
 
@@ -32,7 +33,7 @@ public readonly ref struct OrderedMoveList
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int ScoreMove(
         Piece pieceToMove,
-        Board board, 
+        EngineBoard board, 
         ref OrderedMoveEntry move,
         SearchedMove tableMove
         )
@@ -55,7 +56,8 @@ public readonly ref struct OrderedMoveList
         // The idea behind it is to give highest priority to captures that are capturing most valuable pieces
         // with least valuable pieces.
         Piece to = board.At(move.To).Item1;
-        if (to != Piece.Empty) return MvvLva(board.At(move.From).Item1, to) * 10000;
+        if (to != Piece.Empty) return MvvLva(board.At(move.From).Item1, to) * 10000 + 
+                                      SEE.Approximate(board, ref move);
 
         // If the move is a quiet move (not capture / promotion), then we should check if it is a killer move or history
         // move.
@@ -88,7 +90,7 @@ public readonly ref struct OrderedMoveList
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    public int NormalMoveGeneration(Board board, SearchedMove transpositionMove)
+    public int NormalMoveGeneration(EngineBoard board, SearchedMove transpositionMove)
     {
         PieceColor oppositeColor = board.ColorToMove.OppositeColor();
 
@@ -191,7 +193,7 @@ public readonly ref struct OrderedMoveList
     }
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-    public int QSearchMoveGeneration(Board board, SearchedMove transpositionMove)
+    public int QSearchMoveGeneration(EngineBoard board, SearchedMove transpositionMove)
     {
         PieceColor oppositeColor = board.ColorToMove.OppositeColor();
         // If we only want capture moves, we should also define our opposite board.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -705,9 +705,10 @@ public class MoveSearch
             // Calculate approximation of SEE.
             int see = SEE.Approximate(board, ref move);
             
-            // If SEE + positional evaluation margin is greater than beta, then this capture is far too good, and hence
+            // If SEE + the positional evaluation is greater than beta, then this capture is far too good, and hence
             // causes a beta cutoff.
-            if (see + earlyEval > beta) return beta;
+            int seeEval = see + earlyEval;
+            if (seeEval > beta) return seeEval;
             
             #endregion
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -705,6 +705,12 @@ public class MoveSearch
             // Calculate approximation of SEE.
             int see = SEE.Approximate(board, ref move);
             
+            // Skip moves with a negative SEE.
+            if (see < 0) {
+                i++;
+                continue;
+            }
+            
             // If SEE + positional evaluation margin is greater than beta, then this capture is far too good, and hence
             // causes a beta cutoff.
             if (see + earlyEval > beta) return beta;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -697,9 +697,21 @@ public class MoveSearch
             // We should being the move that's likely to be the best move at this depth to the top. This ensures
             // that we are searching through the likely best moves first, allowing us to return early.
             moveList.SortNext(i, moveCount);
-                
-            // Make the move.
+            
             OrderedMoveEntry move = moveList[i];
+
+            #region SEE Pruning
+            
+            // Calculate approximation of SEE.
+            int see = SEE.Approximate(board, ref move);
+            
+            // If SEE + positional evaluation margin is greater than beta, then this capture is far too good, and hence
+            // causes a beta cutoff.
+            if (see + earlyEval > beta) return beta;
+            
+            #endregion
+            
+            // Make the move.
             RevertMove rv = board.MoveNNUE(ref move);
             TotalNodeSearchCount++;
         

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -471,7 +471,7 @@ public class MoveSearch
 
             #region SEE Pruning
 
-            if (!quietMove) {
+            if (i > 0 && !quietMove) {
                 // Calculate approximation of SEE.
                 int see = SEE.Approximate(board, ref move);
             

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -469,20 +469,6 @@ public class MoveSearch
             bool quietMove = !board.All(oppositeColor)[move.To];
             quietMoveCounter += quietMove.ToByte();
 
-            #region SEE Pruning
-
-            if (!quietMove) {
-                // Calculate approximation of SEE.
-                int see = SEE.Approximate(board, ref move);
-            
-                // If SEE + the positional evaluation is greater than beta, then this capture is far too good, and hence
-                // causes a beta cutoff.
-                int seeEval = see + positionalEvaluation;
-                if (seeEval > beta) return seeEval;
-            }
-            
-            #endregion
-
             #region Futility Pruning
 
             if (i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -469,6 +469,20 @@ public class MoveSearch
             bool quietMove = !board.All(oppositeColor)[move.To];
             quietMoveCounter += quietMove.ToByte();
 
+            #region SEE Pruning
+
+            if (!quietMove) {
+                // Calculate approximation of SEE.
+                int see = SEE.Approximate(board, ref move);
+            
+                // If SEE + the positional evaluation is greater than beta, then this capture is far too good, and hence
+                // causes a beta cutoff.
+                int seeEval = see + positionalEvaluation;
+                if (seeEval > beta) return seeEval;
+            }
+            
+            #endregion
+
             #region Futility Pruning
 
             if (i > 0 && quietMove && positionalEvaluation + depth * FUTILITY_DEPTH_FACTOR <= alpha) 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -705,12 +705,6 @@ public class MoveSearch
             // Calculate approximation of SEE.
             int see = SEE.Approximate(board, ref move);
             
-            // Skip moves with a negative SEE.
-            if (see < 0) {
-                i++;
-                continue;
-            }
-            
             // If SEE + positional evaluation margin is greater than beta, then this capture is far too good, and hence
             // causes a beta cutoff.
             if (see + earlyEval > beta) return beta;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -471,7 +471,7 @@ public class MoveSearch
 
             #region SEE Pruning
 
-            if (i > 0 && !quietMove) {
+            if (!quietMove) {
                 // Calculate approximation of SEE.
                 int see = SEE.Approximate(board, ref move);
             

--- a/Backend/Engine/SEE.cs
+++ b/Backend/Engine/SEE.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.CompilerServices;
+using Backend.Data.Enum;
+using Backend.Data.Struct;
+
+namespace Backend.Engine;
+
+public static class SEE
+{
+
+    private static readonly int[] Internal = { 82, 477, 337, 365, 1025, 0, 0 };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Approximate(EngineBoard board, ref OrderedMoveEntry move)
+    {
+        Piece from = board.PieceOnly(move.From);
+        Piece to = board.PieceOnly(move.To);
+        
+        // In case of En Passant, we set the target piece to a pawn.
+        if (from == Piece.Pawn && move.To == board.EnPassantTarget) to = Piece.Pawn;
+
+        int value = Internal.AA((int)to);
+        
+        if (move.Promotion != Promotion.None)
+            // In the case of a promotion, increment with the difference of the promotion and pawn.
+            value += Internal.AA((int)move.Promotion) - Internal.AA((int)Piece.Pawn);
+
+        return value - Internal.AA((int)from);
+    }
+
+}


### PR DESCRIPTION
This PR implements approximated static exchange evaluation in QSearch, avoiding approximated bad captures.

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 23.33 +- 10.59 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2312 W: 722 L: 567 D: 1023
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 28.82 +- 11.56 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1776 W: 526 L: 379 D: 871
```