### PR TITLE
Search Stack to allow better API for recursive search.

### DIFF
--- a/Backend/Data/MoveSearchStack.cs
+++ b/Backend/Data/MoveSearchStack.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+using Backend.Data.Struct;
+
+namespace Backend.Data;
+
+public class MoveSearchStack
+{
+
+    private const int SIZE = 128;
+
+    private readonly MoveSearchStackItem[] Internal = new MoveSearchStackItem[SIZE];
+
+    public ref MoveSearchStackItem this[int ply]
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref Internal.AA(ply);
+    }
+
+}

--- a/Backend/Data/Struct/MoveSearchStackItem.cs
+++ b/Backend/Data/Struct/MoveSearchStackItem.cs
@@ -1,0 +1,8 @@
+﻿namespace Backend.Data.Struct;
+
+public struct MoveSearchStackItem
+{
+
+    public int PositionalEvaluation;
+
+}

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -59,7 +59,7 @@ public class MoveSearch
     private readonly MoveSearchEffortTable SearchEffort = new();
     private readonly PrincipleVariationTable PvTable = new();
 
-    private readonly int[] PositionalEvaluationStore = new int[128];
+    private readonly MoveSearchStack MoveSearchStack = new();
 
     private readonly EngineBoard Board;
     private readonly TimeControl TimeControl;
@@ -313,12 +313,13 @@ public class MoveSearch
             transpositionMove.Evaluation : Evaluation.RelativeEvaluation(board);
             
         // Also store the evaluation to later check if it improved.
-        PositionalEvaluationStore.AA(plyFromRoot) = positionalEvaluation;
+        MoveSearchStack[plyFromRoot].PositionalEvaluation = positionalEvaluation;
         
         // ReSharper disable once ConvertIfStatementToSwitchStatement
         if (typeof(Node) != typeof(PvNode) && !inCheck) {
             // Roughly estimate whether the deeper search improves the position or not.
-            improving = plyFromRoot >= 2 && positionalEvaluation >= PositionalEvaluationStore.AA(plyFromRoot - 2);
+            improving = plyFromRoot >= 2 && 
+                        positionalEvaluation >= MoveSearchStack[plyFromRoot - 2].PositionalEvaluation;
 
             #region Reverse Futility Pruning
 


### PR DESCRIPTION
This PR is an API improvement on the current recursive search information storage.

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | -0.87 +- 3.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.48 (-2.94, 2.94) [-3.00, 2.00]
GAMES | N: 17240 W: 4719 L: 4762 D: 7759
```

After a reasonable amount of games in a non-regressive test, it is evident that this change doesn't cause any noticeable ELO gain or loss. This PR is thus, safe to merge.