### PR TITLE
Improve Transposition Table Replacement Scheme.

### DIFF
--- a/Backend/Data/MoveTranspositionTable.cs
+++ b/Backend/Data/MoveTranspositionTable.cs
@@ -53,12 +53,6 @@ public unsafe class MoveTranspositionTable
         int index = (int)zobristHash & HashFilter;
         ref MoveTranspositionTableEntry oldEntry = ref Internal.AA(index);
 
-        if (oldEntry.Type == MoveTranspositionTableEntryType.Invalid) {
-            // If the previous entry wasn't valid (there was no previous entry), replace it with the new entry. 
-            Internal.AA(index) = entry;
-            return;
-        }
-
         // If the old entry is higher than the new entry by a depth more than the threshold, than avoid replacing it.
         if (entry.Type == MoveTranspositionTableEntryType.Exact || entry.ZobristHash != oldEntry.ZobristHash || 
             entry.Depth > oldEntry.Depth - REPLACEMENT_DEPTH_THRESHOLD)

--- a/Backend/Data/MoveTranspositionTable.cs
+++ b/Backend/Data/MoveTranspositionTable.cs
@@ -10,9 +10,8 @@ namespace Backend.Data;
 
 public unsafe class MoveTranspositionTable
 {
-
     private const int MB_TO_B = 1_048_576;
-    
+
     private const int REPLACEMENT_DEPTH_THRESHOLD = 3;
 
     private readonly int HashFilter;
@@ -25,18 +24,19 @@ public unsafe class MoveTranspositionTable
     {
         HashFilter = 0x0;
 
-        for (int i = 0x1; byteSize >= (i + 1) * sizeof(MoveTranspositionTableEntry); i = (i << 1) | 0x1) {
+        for (int i = 0x1; byteSize >= (i + 1) * sizeof(MoveTranspositionTableEntry); i = (i << 1) | 0x1)
+        {
             HashFilter = i;
         }
 
         Internal = new MoveTranspositionTableEntry[HashFilter + 1];
 
-        Parallel.For(0, HashFilter + 1, i => 
+        Parallel.For(0, HashFilter + 1, i =>
             Internal[i] = new MoveTranspositionTableEntry()
         );
 
 #if DEBUG
-        Console.WriteLine("Allocated " + HashFilter * sizeof(MoveTranspositionTableEntry) + 
+        Console.WriteLine("Allocated " + HashFilter * sizeof(MoveTranspositionTableEntry) +
                           " bytes for " + HashFilter + " TT entries.");
 #endif
     }
@@ -52,18 +52,21 @@ public unsafe class MoveTranspositionTable
     {
         int index = (int)zobristHash & HashFilter;
         ref MoveTranspositionTableEntry oldEntry = ref Internal.AA(index);
-        
-        if (oldEntry.Type == MoveTranspositionTableEntryType.Invalid) {
+
+        if (oldEntry.Type == MoveTranspositionTableEntryType.Invalid)
+        {
             // If the previous entry wasn't valid (there was no previous entry), replace it with the new entry. 
             Internal.AA(index) = entry;
             return;
         }
-        
+
         // If the old entry is higher than the new entry by a depth more than the threshold, than avoid replacing it.
-        if (oldEntry.Depth - REPLACEMENT_DEPTH_THRESHOLD > entry.Depth) return;
-        Internal.AA(index) = entry;
+        if (entry.Type == MoveTranspositionTableEntryType.Exact
+            || entry.ZobristHash != oldEntry.ZobristHash
+            || entry.Depth > oldEntry.Depth - REPLACEMENT_DEPTH_THRESHOLD
+           )
+            Internal.AA(index) = entry;
     }
 
     public void FreeMemory() => Internal = null;
-
 }

--- a/Backend/Data/MoveTranspositionTable.cs
+++ b/Backend/Data/MoveTranspositionTable.cs
@@ -10,6 +10,7 @@ namespace Backend.Data;
 
 public unsafe class MoveTranspositionTable
 {
+
     private const int MB_TO_B = 1_048_576;
 
     private const int REPLACEMENT_DEPTH_THRESHOLD = 3;
@@ -24,19 +25,18 @@ public unsafe class MoveTranspositionTable
     {
         HashFilter = 0x0;
 
-        for (int i = 0x1; byteSize >= (i + 1) * sizeof(MoveTranspositionTableEntry); i = (i << 1) | 0x1)
-        {
+        for (int i = 0x1; byteSize >= (i + 1) * sizeof(MoveTranspositionTableEntry); i = (i << 1) | 0x1) {
             HashFilter = i;
         }
 
         Internal = new MoveTranspositionTableEntry[HashFilter + 1];
 
-        Parallel.For(0, HashFilter + 1, i =>
+        Parallel.For(0, HashFilter + 1, i => 
             Internal[i] = new MoveTranspositionTableEntry()
         );
 
 #if DEBUG
-        Console.WriteLine("Allocated " + HashFilter * sizeof(MoveTranspositionTableEntry) +
+        Console.WriteLine("Allocated " + HashFilter * sizeof(MoveTranspositionTableEntry) + 
                           " bytes for " + HashFilter + " TT entries.");
 #endif
     }
@@ -53,20 +53,18 @@ public unsafe class MoveTranspositionTable
         int index = (int)zobristHash & HashFilter;
         ref MoveTranspositionTableEntry oldEntry = ref Internal.AA(index);
 
-        if (oldEntry.Type == MoveTranspositionTableEntryType.Invalid)
-        {
+        if (oldEntry.Type == MoveTranspositionTableEntryType.Invalid) {
             // If the previous entry wasn't valid (there was no previous entry), replace it with the new entry. 
             Internal.AA(index) = entry;
             return;
         }
 
         // If the old entry is higher than the new entry by a depth more than the threshold, than avoid replacing it.
-        if (entry.Type == MoveTranspositionTableEntryType.Exact
-            || entry.ZobristHash != oldEntry.ZobristHash
-            || entry.Depth > oldEntry.Depth - REPLACEMENT_DEPTH_THRESHOLD
-           )
+        if (entry.Type == MoveTranspositionTableEntryType.Exact || entry.ZobristHash != oldEntry.ZobristHash || 
+            entry.Depth > oldEntry.Depth - REPLACEMENT_DEPTH_THRESHOLD)
             Internal.AA(index) = entry;
     }
 
     public void FreeMemory() => Internal = null;
+    
 }


### PR DESCRIPTION
This PR improves the current replacement scheme for the transposition table. It makes it more generous to exact entries.

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 13.83 +- 7.80 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4248 W: 1268 L: 1099 D: 1881
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 9.21 +- 6.06 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6640 W: 1836 L: 1660 D: 3144
```