### PR TITLE
Improve Neural Network Operation Cache Locality.

### DIFF
--- a/Backend/Board.cs
+++ b/Backend/Board.cs
@@ -120,8 +120,7 @@ public class Board
         // Make the move.
         Map.Move(pieceF, colorF, pieceT, colorT, from, to);
         
-        Evaluation.NNUE.EfficientlyUpdateAccumulator<Deactivate>(pieceF, colorF, from);
-        Evaluation.NNUE.EfficientlyUpdateAccumulator<Activate>(pieceF, colorF, to);
+        Evaluation.NNUE.EfficientlyUpdateAccumulator(pieceF, colorF, from, to);
 
         if (promotion != Promotion.None) {
             Map.Empty(pieceF, colorF, to);
@@ -209,8 +208,7 @@ public class Board
                         rv.SecondaryFrom, rv.SecondaryTo
                     );
                     
-                    Evaluation.NNUE.EfficientlyUpdateAccumulator<Deactivate>(Piece.Rook, colorF, rv.SecondaryFrom);
-                    Evaluation.NNUE.EfficientlyUpdateAccumulator<Activate>(Piece.Rook, colorF, rv.SecondaryTo);
+                    Evaluation.NNUE.EfficientlyUpdateAccumulator(Piece.Rook, colorF, rv.SecondaryFrom, rv.SecondaryTo);
                 }
 
                 break;

--- a/Backend/Engine/NNUE/Vectorization/NN.cs
+++ b/Backend/Engine/NNUE/Vectorization/NN.cs
@@ -171,6 +171,62 @@ public static class NN
             vectorIndex = unrolledIndex3 + VSize.Short;
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void AddToAll(short[] inputA, short[] inputB, short[] delta, int offsetA, int offsetB)
+    {
+        int size = inputA.Length;
+        int loopSize = size / VSize.Short / UNROLL;
+
+        int vectorIndex = 0;
+        for (int i = 0; i < loopSize; i++) {
+            int unrolledIndex = vectorIndex + VSize.Short;
+            int unrolledIndex2 = unrolledIndex + VSize.Short;
+            int unrolledIndex3 = unrolledIndex2 + VSize.Short;
+            
+            Vector<short> iAVec = inputA.NewVector(vectorIndex);
+            Vector<short> dAVec = delta.NewVector(offsetA + vectorIndex);
+            Vector<short> rAVec = iAVec + dAVec;
+            rAVec.ToArray(inputA, vectorIndex);
+            
+            Vector<short> iAVec2 = inputA.NewVector(unrolledIndex);
+            Vector<short> dAVec2 = delta.NewVector(offsetA + unrolledIndex);
+            Vector<short> rAVec2 = iAVec2 + dAVec2;
+            rAVec2.ToArray(inputA, unrolledIndex);
+            
+            Vector<short> iAVec3 = inputA.NewVector(unrolledIndex2);
+            Vector<short> dAVec3 = delta.NewVector(offsetA + unrolledIndex2);
+            Vector<short> rAVec3 = iAVec3 + dAVec3;
+            rAVec3.ToArray(inputA, unrolledIndex2);
+            
+            Vector<short> iAVec4 = inputA.NewVector(unrolledIndex3);
+            Vector<short> dAVec4 = delta.NewVector(offsetA + unrolledIndex3);
+            Vector<short> rAVec4 = iAVec4 + dAVec4;
+            rAVec4.ToArray(inputA, unrolledIndex3);
+            
+            Vector<short> iBVec = inputB.NewVector(vectorIndex);
+            Vector<short> dBVec = delta.NewVector(offsetB + vectorIndex);
+            Vector<short> rBVec = iBVec + dBVec;
+            rBVec.ToArray(inputB, vectorIndex);
+            
+            Vector<short> iBVec2 = inputB.NewVector(unrolledIndex);
+            Vector<short> dBVec2 = delta.NewVector(offsetB + unrolledIndex);
+            Vector<short> rBVec2 = iBVec2 + dBVec2;
+            rBVec2.ToArray(inputB, unrolledIndex);
+            
+            Vector<short> iBVec3 = inputB.NewVector(unrolledIndex2);
+            Vector<short> dBVec3 = delta.NewVector(offsetB + unrolledIndex2);
+            Vector<short> rBVec3 = iBVec3 + dBVec3;
+            rBVec3.ToArray(inputB, unrolledIndex2);
+            
+            Vector<short> iBVec4 = inputB.NewVector(unrolledIndex3);
+            Vector<short> dBVec4 = delta.NewVector(offsetB + unrolledIndex3);
+            Vector<short> rBVec4 = iBVec4 + dBVec4;
+            rBVec4.ToArray(inputB, unrolledIndex3);
+
+            vectorIndex = unrolledIndex3 + VSize.Short;
+        }
+    }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void SubtractFromAll(short[] input, short[] delta, int offset)
@@ -202,6 +258,102 @@ public static class NN
             Vector<short> iVec4 = input.NewVector(unrolledIndex3);
             Vector<short> dVec4 = delta.NewVector(offset + unrolledIndex3);
             Vector<short> rVec4 = iVec4 - dVec4;
+            rVec4.ToArray(input, unrolledIndex3);
+
+            vectorIndex = unrolledIndex3 + VSize.Short;
+        }
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void SubtractFromAll(short[] inputA, short[] inputB, short[] delta, int offsetA, int offsetB)
+    {
+        int size = inputA.Length;
+        int loopSize = size / VSize.Short / UNROLL;
+
+        int vectorIndex = 0;
+        for (int i = 0; i < loopSize; i++) {
+            int unrolledIndex = vectorIndex + VSize.Short;
+            int unrolledIndex2 = unrolledIndex + VSize.Short;
+            int unrolledIndex3 = unrolledIndex2 + VSize.Short;
+            
+            Vector<short> iAVec = inputA.NewVector(vectorIndex);
+            Vector<short> dAVec = delta.NewVector(offsetA + vectorIndex);
+            Vector<short> rAVec = iAVec - dAVec;
+            rAVec.ToArray(inputA, vectorIndex);
+            
+            Vector<short> iAVec2 = inputA.NewVector(unrolledIndex);
+            Vector<short> dAVec2 = delta.NewVector(offsetA + unrolledIndex);
+            Vector<short> rAVec2 = iAVec2 - dAVec2;
+            rAVec2.ToArray(inputA, unrolledIndex);
+            
+            Vector<short> iAVec3 = inputA.NewVector(unrolledIndex2);
+            Vector<short> dAVec3 = delta.NewVector(offsetA + unrolledIndex2);
+            Vector<short> rAVec3 = iAVec3 - dAVec3;
+            rAVec3.ToArray(inputA, unrolledIndex2);
+            
+            Vector<short> iAVec4 = inputA.NewVector(unrolledIndex3);
+            Vector<short> dAVec4 = delta.NewVector(offsetA + unrolledIndex3);
+            Vector<short> rAVec4 = iAVec4 - dAVec4;
+            rAVec4.ToArray(inputA, unrolledIndex3);
+            
+            Vector<short> iBVec = inputB.NewVector(vectorIndex);
+            Vector<short> dBVec = delta.NewVector(offsetB + vectorIndex);
+            Vector<short> rBVec = iBVec - dBVec;
+            rBVec.ToArray(inputB, vectorIndex);
+            
+            Vector<short> iBVec2 = inputB.NewVector(unrolledIndex);
+            Vector<short> dBVec2 = delta.NewVector(offsetB + unrolledIndex);
+            Vector<short> rBVec2 = iBVec2 - dBVec2;
+            rBVec2.ToArray(inputB, unrolledIndex);
+            
+            Vector<short> iBVec3 = inputB.NewVector(unrolledIndex2);
+            Vector<short> dBVec3 = delta.NewVector(offsetB + unrolledIndex2);
+            Vector<short> rBVec3 = iBVec3 - dBVec3;
+            rBVec3.ToArray(inputB, unrolledIndex2);
+            
+            Vector<short> iBVec4 = inputB.NewVector(unrolledIndex3);
+            Vector<short> dBVec4 = delta.NewVector(offsetB + unrolledIndex3);
+            Vector<short> rBVec4 = iBVec4 - dBVec4;
+            rBVec4.ToArray(inputB, unrolledIndex3);
+
+            vectorIndex = unrolledIndex3 + VSize.Short;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void SubtractAndAddToAll(short[] input, short[] delta, int offsetS, int offsetA)
+    {
+        int size = input.Length;
+        int loopSize = size / VSize.Short / UNROLL;
+
+        int vectorIndex = 0;
+        for (int i = 0; i < loopSize; i++) {
+            int unrolledIndex = vectorIndex + VSize.Short;
+            int unrolledIndex2 = unrolledIndex + VSize.Short;
+            int unrolledIndex3 = unrolledIndex2 + VSize.Short;
+
+            Vector<short> iVec = input.NewVector(vectorIndex);
+            Vector<short> dSVec = delta.NewVector(offsetS + vectorIndex);
+            Vector<short> dAVec = delta.NewVector(offsetA + vectorIndex);
+            Vector<short> rVec = iVec - dSVec + dAVec;
+            rVec.ToArray(input, vectorIndex);
+            
+            Vector<short> iVec2 = input.NewVector(unrolledIndex);
+            Vector<short> dSVec2 = delta.NewVector(offsetS + unrolledIndex);
+            Vector<short> dAVec2 = delta.NewVector(offsetA + unrolledIndex);
+            Vector<short> rVec2 = iVec2 - dSVec2 + dAVec2;
+            rVec2.ToArray(input, unrolledIndex);
+            
+            Vector<short> iVec3 = input.NewVector(unrolledIndex2);
+            Vector<short> dSVec3 = delta.NewVector(offsetS + unrolledIndex2);
+            Vector<short> dAVec3 = delta.NewVector(offsetA + unrolledIndex2);
+            Vector<short> rVec3 = iVec3 - dSVec3 + dAVec3;
+            rVec3.ToArray(input, unrolledIndex2);
+            
+            Vector<short> iVec4 = input.NewVector(unrolledIndex3);
+            Vector<short> dSVec4 = delta.NewVector(offsetS + unrolledIndex3);
+            Vector<short> dAVec4 = delta.NewVector(offsetA + unrolledIndex3);
+            Vector<short> rVec4 = iVec4 - dSVec4 + dAVec4;
             rVec4.ToArray(input, unrolledIndex3);
 
             vectorIndex = unrolledIndex3 + VSize.Short;

--- a/Backend/Engine/NNUE/Vectorization/NN.cs
+++ b/Backend/Engine/NNUE/Vectorization/NN.cs
@@ -59,6 +59,8 @@ public static class NN
         }
     }
     
+#if DEBUG
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Forward(short[] input, short[] weight, int[] output, int offset = 0)
     {
@@ -97,6 +99,8 @@ public static class NN
             weightStride += inputSize;
         }
     }
+
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ClippedReLUFlattenAndForward(short[] inputA, short[] inputB, short[] bias, short[] weight, 
@@ -161,7 +165,9 @@ public static class NN
             weightStride += inputSize;
         }
     }
-    
+
+#if DEBUG
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ClippedReLU(short[] input, short[] bias, short[] output, short min, short max, int offset = 0)
     {
@@ -199,6 +205,8 @@ public static class NN
             vectorIndex = unrolledIndex3 + VSize.Short;
         }
     }
+
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AddToAll(short[] inputA, short[] inputB, short[] delta, int offsetA, int offsetB)

--- a/Benchmark/NNUE.cs
+++ b/Benchmark/NNUE.cs
@@ -24,7 +24,13 @@ public class NNUE
     }
 
     [Benchmark]
-    public void Eua()
+    public void EuaNormal()
+    {
+        BasicNNUE.EfficientlyUpdateAccumulator(Piece.Pawn, PieceColor.White, Square.E2, Square.E4);
+    }
+
+    [Benchmark]
+    public void EuaGeneric()
     {
         BasicNNUE.EfficientlyUpdateAccumulator<Deactivate>(Piece.Pawn, PieceColor.White, Square.E2);
         BasicNNUE.EfficientlyUpdateAccumulator<Activate>(Piece.Pawn, PieceColor.White, Square.E4);


### PR DESCRIPTION
This PR improves the cache locality of the present neural network within StockNemo. It combines operations to avoid numerous memory accesses & reuse already loaded vectors. 

```
       IN          ACCUMULATOR                               HIDDEN                                    OUT
 ______________      _______      ______________________________________________________________      _____
| WHITE: (768) | -> | (256) | -> | ClippedReLU(0, 1) -> (256) \                                 |    |     |
|              |    |       |    |                             \                                |    |     |
|              |    |       |    |                              CONCATENATE(ColorToMove): (512) | -> | (1) |
|              |    |       |    |                             /                                |    |     |
| BLACK: (768) | -> | (256) | -> | ClippedReLU(0, 1) -> (256) /                                 |    |     |
 --------------      -------      --------------------------------------------------------------      -----

Data: 1.2B FEN
Epochs: 40
```

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 13.44 +- 7.68 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4344 W: 1285 L: 1117 D: 1942
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 9.68 +- 6.16 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6136 W: 1629 L: 1458 D: 3049
```