### PR TITLE
Update History Heuristics on Beta Cutoffs.

### DIFF
--- a/Backend/Data/Struct/OrderedMoveList.cs
+++ b/Backend/Data/Struct/OrderedMoveList.cs
@@ -60,8 +60,8 @@ public readonly ref struct OrderedMoveList
         // If the move is a quiet move (not capture / promotion), then we should check if it is a killer move or history
         // move.
         // Killer moves are moves that are very likely to cause a beta cutoff.
-        // History moves are moves that have been scored as most likely alpha changing moves, depending on how many
-        // times the move changed alpha (gave us a guaranteed best move).
+        // History moves are moves that have been scored as most likely beta cutoff moves, depending on how many
+        // times the move has caused a beta cutoff (gave us a guaranteed best move).
         
         // Check if move is a rank 1 killer move (extremely local, recently updated).
         if (move == KillerMoveOne) return 900000;

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -448,10 +448,6 @@ public class MoveSearch
             // replace our alpha with our evaluation.
             alpha = evaluation;
             
-            // Update our history table with our alpha-changing quiet move in hopes we can find similar best
-            // moves faster.
-            if (quietMove) HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += depth;
-            
             // Our alpha changed, so it is no longer an unchanged alpha entry.
             transpositionTableEntryType = MoveTranspositionTableEntryType.Exact;
             
@@ -575,12 +571,17 @@ public class MoveSearch
             board.UndoMove<NNUpdate>(ref rv);
 
             if (!HandleEvaluation(evaluation, ref move, quietMove)) {
-                if (quietMove && KillerMoveTable[0, plyFromRoot] != move) {
-                    // Given this move isn't a capture move (quiet move), we store it as a killer move (cutoff move) to
-                    // better sort quiet moves like these in the future, allowing us to achieve a cutoff faster. Also
-                    // make sure we are not saving same move in both of our caches.
-                    KillerMoveTable.ReOrder(plyFromRoot);
-                    KillerMoveTable[0, plyFromRoot] = move;
+                if (quietMove) {
+                    if (KillerMoveTable[0, plyFromRoot] != move) {
+                        // Given this move isn't a capture move (quiet move), we store it as a killer move (cutoff move)
+                        // to better sort quiet moves like these in the future, allowing us to achieve a cutoff faster.
+                        // Also make sure we are not saving same move in both of our caches.
+                        KillerMoveTable.ReOrder(plyFromRoot);
+                        KillerMoveTable[0, plyFromRoot] = move;
+                    }
+                    
+                    // Save a more generalized score of beta-cutoff moves in our history table.
+                    HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += depth;
                 }
 
                 // We had a beta cutoff, hence it's a beta cutoff entry.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -581,7 +581,7 @@ public class MoveSearch
                     }
                     
                     // Save a more generalized score of beta-cutoff moves in our history table.
-                    HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += depth;
+                    HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += depth * depth;
                 }
 
                 // We had a beta cutoff, hence it's a beta cutoff entry.


### PR DESCRIPTION
This PR improves the history heuristic by updating it on beta cutoffs instead of alpha changes.

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 6.12 +- 4.59 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 11984 W: 3374 L: 3163 D: 5447
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 5.63 +- 3.63 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 17720 W: 4617 L: 4330 D: 8773
```