### PR TITLE
Decrement History Heuristic Scores for non-best moves.

### DIFF
--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -583,6 +583,14 @@ public class MoveSearch
                     
                     // Increment the move that caused a beta cutoff to get a historical heuristic of best quiet moves.
                     HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += historyBonus;
+                    
+                    // Decrement all other quiet moves to ensure a branch local history heuristic.
+                    int j = 1;
+                    while (j < quietMoveCounter) {
+                        OrderedMoveEntry otherMove = moveList[i - j];
+                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= historyBonus;
+                        j++;
+                    }
                 }
 
                 // We had a beta cutoff, hence it's a beta cutoff entry.

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -588,8 +588,7 @@ public class MoveSearch
                     int j = 1;
                     while (j < quietMoveCounter) {
                         OrderedMoveEntry otherMove = moveList[i - j];
-                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth * 
-                            Math.Min(depth, 5);
+                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth;
                         j++;
                     }
                 }

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -443,12 +443,7 @@ public class MoveSearch
                 PvTable.UpdateLength(plyFromRoot);
             }
 
-            if (evaluation <= alpha) {
-                // Decrement history if move wasn't able to change alpha.
-                if (quietMove) HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] -= historyBonus;
-                
-                return true;
-            }
+            if (evaluation <= alpha) return true;
 
             // If our evaluation was better than our alpha (best unavoidable evaluation so far), then we should
             // replace our alpha with our evaluation.
@@ -586,7 +581,7 @@ public class MoveSearch
                         KillerMoveTable[0, plyFromRoot] = move;
                     }
                     
-                    // Save a more generalized score of beta-cutoff moves in our history table.
+                    // Increment the move that caused a beta cutoff to get a historical heuristic of best quiet moves.
                     HistoryTable[board.PieceOnly(move.From), board.ColorToMove, move.To] += historyBonus;
                 }
 

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -588,7 +588,7 @@ public class MoveSearch
                     int j = 1;
                     while (j < quietMoveCounter) {
                         OrderedMoveEntry otherMove = moveList[i - j];
-                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= historyBonus;
+                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth;
                         j++;
                     }
                 }

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -588,7 +588,7 @@ public class MoveSearch
                     int j = 1;
                     while (j < quietMoveCounter) {
                         OrderedMoveEntry otherMove = moveList[i - j];
-                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth;
+                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= historyBonus;
                         j++;
                     }
                 }

--- a/Backend/Engine/MoveSearch.cs
+++ b/Backend/Engine/MoveSearch.cs
@@ -588,7 +588,8 @@ public class MoveSearch
                     int j = 1;
                     while (j < quietMoveCounter) {
                         OrderedMoveEntry otherMove = moveList[i - j];
-                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth;
+                        HistoryTable[board.PieceOnly(otherMove.From), board.ColorToMove, otherMove.To] -= depth * 
+                            Math.Min(depth, 5);
                         j++;
                     }
                 }


### PR DESCRIPTION
This PR implements functionality to decrement all moves that weren't the best whenever the best move is found. Such ensures an ideal branch local history heuristic.

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 40.59 +- 13.89 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1264 W: 403 L: 256 D: 605
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 39.94 +- 13.43 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1232 W: 364 L: 223 D: 645
```