### PR TITLE
Optimize away duplicate address loading instructions.

### DIFF
--- a/Backend/Engine/NNUE/Architecture/Basic/BasicNNUE.cs
+++ b/Backend/Engine/NNUE/Architecture/Basic/BasicNNUE.cs
@@ -39,9 +39,6 @@ public class BasicNNUE
     private readonly short[] BlackPOV = new short[INPUT];
 
     private readonly BasicAccumulator<short>[] Accumulators = new BasicAccumulator<short>[ACCUMULATOR_STACK_SIZE];
-    
-    // ReSharper disable once UnusedMember.Local
-    private readonly short[] Flatten = new short[HIDDEN * 2];
 
     private readonly int[] Output = new int[OUTPUT];
     
@@ -162,19 +159,8 @@ public class BasicNNUE
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public int Evaluate(PieceColor colorToMove)
     {
-#if DEBUG
-        int firstOffset = 0;
-        int secondOffset = 256;
-
-        if (colorToMove == PieceColor.Black) {
-            firstOffset = 256;
-            secondOffset = 0;
-        }
-#endif
-        
         BasicAccumulator<short> accumulator = Accumulators.AA(CurrentAccumulator);
 
-#if RELEASE
         if (colorToMove == PieceColor.White) {
             NN.ClippedReLUFlattenAndForward(accumulator.A, accumulator.B, FeatureBias, OutWeight, Output, 
                 CR_MIN, CR_MAX, HIDDEN);
@@ -182,14 +168,6 @@ public class BasicNNUE
             NN.ClippedReLUFlattenAndForward(accumulator.B, accumulator.A, FeatureBias, OutWeight, Output, 
                 CR_MIN, CR_MAX, HIDDEN);
         }
-#endif
-        
-#if DEBUG
-        NN.ClippedReLU(accumulator.A, FeatureBias, Flatten, CR_MIN, CR_MAX, firstOffset);
-        NN.ClippedReLU(accumulator.B, FeatureBias, Flatten, CR_MIN, CR_MAX, secondOffset);
-        
-        NN.Forward(Flatten, OutWeight, Output);
-#endif
         
         return (Output.AA(0) + OutBias.AA(0)) * SCALE / QAB;
     }

--- a/Backend/Engine/NNUE/Vectorization/NN.cs
+++ b/Backend/Engine/NNUE/Vectorization/NN.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Backend.Data.Enum;
 
 namespace Backend.Engine.NNUE.Vectorization;
@@ -28,6 +29,9 @@ public static class NN
         int outputSize = output.Length;
         int weightStride = 0;
 
+        ref short inputReference = ref MemoryMarshal.GetArrayDataReference(input);
+        ref short weightReference = ref MemoryMarshal.GetArrayDataReference(weight);
+
         for (int i = 0; i < outputSize; i++) {
             Vector<short> sum = Vector<short>.Zero;
             int vectorIndex = 0;
@@ -36,20 +40,20 @@ public static class NN
                 int unrolledIndex2 = unrolledIndex + VSize.Short;
                 int unrolledIndex3 = unrolledIndex2 + VSize.Short;
                 
-                Vector<short> iVec = input.LoadVector(vectorIndex);
-                Vector<short> wVec = weight.LoadVector(weightStride + vectorIndex);
+                Vector<short> iVec = inputReference.LoadVector(vectorIndex);
+                Vector<short> wVec = weightReference.LoadVector(weightStride + vectorIndex);
                 sum += iVec * wVec;
                 
-                Vector<short> iVec2 = input.LoadVector(unrolledIndex);
-                Vector<short> wVec2 = weight.LoadVector(weightStride + unrolledIndex);
+                Vector<short> iVec2 = inputReference.LoadVector(unrolledIndex);
+                Vector<short> wVec2 = weightReference.LoadVector(weightStride + unrolledIndex);
                 sum += iVec2 * wVec2;
                 
-                Vector<short> iVec3 = input.LoadVector(unrolledIndex2);
-                Vector<short> wVec3 = weight.LoadVector(weightStride + unrolledIndex2);
+                Vector<short> iVec3 = inputReference.LoadVector(unrolledIndex2);
+                Vector<short> wVec3 = weightReference.LoadVector(weightStride + unrolledIndex2);
                 sum += iVec3 * wVec3;
                 
-                Vector<short> iVec4 = input.LoadVector(unrolledIndex3);
-                Vector<short> wVec4 = weight.LoadVector(weightStride + unrolledIndex3);
+                Vector<short> iVec4 = inputReference.LoadVector(unrolledIndex3);
+                Vector<short> wVec4 = weightReference.LoadVector(weightStride + unrolledIndex3);
                 sum += iVec4 * wVec4;
                 
                 vectorIndex = unrolledIndex3 + VSize.Short;
@@ -58,49 +62,6 @@ public static class NN
             weightStride += inputSize;
         }
     }
-    
-#if DEBUG
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Forward(short[] input, short[] weight, int[] output, int offset = 0)
-    {
-        int inputSize = input.Length;
-        int loopSize = inputSize / VSize.Short / UNROLL;
-        int outputSize = output.Length;
-        int weightStride = 0;
-
-        for (int i = 0; i < outputSize; i++) {
-            Vector<int> sum = Vector<int>.Zero;
-            int vectorIndex = 0;
-            for (int j = 0; j < loopSize; j++) {
-                int unrolledIndex = vectorIndex + VSize.Short;
-                int unrolledIndex2 = unrolledIndex + VSize.Short;
-                int unrolledIndex3 = unrolledIndex2 + VSize.Short;
-                
-                Vector<short> iVec = input.LoadVector(vectorIndex);
-                Vector<short> wVec = weight.LoadVector(weightStride + vectorIndex);
-                sum += VMethod.MultiplyAddAdjacent(iVec, wVec);
-                
-                Vector<short> iVec2 = input.LoadVector(unrolledIndex);
-                Vector<short> wVec2 = weight.LoadVector(weightStride + unrolledIndex);
-                sum += VMethod.MultiplyAddAdjacent(iVec2, wVec2);
-                
-                Vector<short> iVec3 = input.LoadVector(unrolledIndex2);
-                Vector<short> wVec3 = weight.LoadVector(weightStride + unrolledIndex2);
-                sum += VMethod.MultiplyAddAdjacent(iVec3, wVec3);
-                
-                Vector<short> iVec4 = input.LoadVector(unrolledIndex3);
-                Vector<short> wVec4 = weight.LoadVector(weightStride + unrolledIndex3);
-                sum += VMethod.MultiplyAddAdjacent(iVec4, wVec4);
-                
-                vectorIndex = unrolledIndex3 + VSize.Short;
-            }
-            output.AA(offset + i) = Vector.Sum(sum);
-            weightStride += inputSize;
-        }
-    }
-
-#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ClippedReLUFlattenAndForward(short[] inputA, short[] inputB, short[] bias, short[] weight, 
@@ -114,8 +75,11 @@ public static class NN
         Vector<short> minVec = new(min);
         Vector<short> maxVec = new(max);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        short[] InputReference(int index) => index < separationIndex ? inputA : inputB;
+        ref short inputAReference = ref MemoryMarshal.GetArrayDataReference(inputA);
+        ref short inputBReference = ref MemoryMarshal.GetArrayDataReference(inputB);
+        ref short biasReference = ref MemoryMarshal.GetArrayDataReference(bias);
+        ref short weightReference = ref MemoryMarshal.GetArrayDataReference(weight);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         int RelativeIndex(int index) => index < separationIndex ? index : index - separationIndex;
 
@@ -123,7 +87,8 @@ public static class NN
             Vector<int> sum = Vector<int>.Zero;
             int vectorIndex = 0;
             for (int j = 0; j < loopSize; j++) {
-                short[] input = InputReference(vectorIndex);
+                ref short inputReference = ref vectorIndex < separationIndex ? 
+                    ref inputAReference : ref inputBReference;
 
                 int unrolledIndex = vectorIndex + VSize.Short;
                 int unrolledIndex2 = unrolledIndex + VSize.Short;
@@ -134,27 +99,27 @@ public static class NN
                 int unrolledRIndex2 = unrolledRIndex + VSize.Short;
                 int unrolledRIndex3 = unrolledRIndex2 + VSize.Short;
 
-                Vector<short> iVec = input.LoadVector(rIndex);
-                Vector<short> bVec = bias.LoadVector(rIndex);
-                Vector<short> wVec = weight.LoadVector(weightStride + vectorIndex);
+                Vector<short> iVec = inputReference.LoadVector(rIndex);
+                Vector<short> bVec = biasReference.LoadVector(rIndex);
+                Vector<short> wVec = weightReference.LoadVector(weightStride + vectorIndex);
                 Vector<short> clamped = (iVec + bVec).Clamp(ref minVec, ref maxVec);
                 sum += VMethod.MultiplyAddAdjacent(clamped, wVec);
                 
-                Vector<short> iVec2 = input.LoadVector(unrolledRIndex);
-                Vector<short> bVec2 = bias.LoadVector(unrolledRIndex);
-                Vector<short> wVec2 = weight.LoadVector(weightStride + unrolledIndex);
+                Vector<short> iVec2 = inputReference.LoadVector(unrolledRIndex);
+                Vector<short> bVec2 = biasReference.LoadVector(unrolledRIndex);
+                Vector<short> wVec2 = weightReference.LoadVector(weightStride + unrolledIndex);
                 Vector<short> clamped2 = (iVec2 + bVec2).Clamp(ref minVec, ref maxVec);
                 sum += VMethod.MultiplyAddAdjacent(clamped2, wVec2);
                 
-                Vector<short> iVec3 = input.LoadVector(unrolledRIndex2);
-                Vector<short> bVec3 = bias.LoadVector(unrolledRIndex2);
-                Vector<short> wVec3 = weight.LoadVector(weightStride + unrolledIndex2);
+                Vector<short> iVec3 = inputReference.LoadVector(unrolledRIndex2);
+                Vector<short> bVec3 = biasReference.LoadVector(unrolledRIndex2);
+                Vector<short> wVec3 = weightReference.LoadVector(weightStride + unrolledIndex2);
                 Vector<short> clamped3 = (iVec3 + bVec3).Clamp(ref minVec, ref maxVec);
                 sum += VMethod.MultiplyAddAdjacent(clamped3, wVec3);
                 
-                Vector<short> iVec4 = input.LoadVector(unrolledRIndex3);
-                Vector<short> bVec4 = bias.LoadVector(unrolledRIndex3);
-                Vector<short> wVec4 = weight.LoadVector(weightStride + unrolledIndex3);
+                Vector<short> iVec4 = inputReference.LoadVector(unrolledRIndex3);
+                Vector<short> bVec4 = biasReference.LoadVector(unrolledRIndex3);
+                Vector<short> wVec4 = weightReference.LoadVector(weightStride + unrolledIndex3);
                 Vector<short> clamped4 = (iVec4 + bVec4).Clamp(ref minVec, ref maxVec);
                 sum += VMethod.MultiplyAddAdjacent(clamped4, wVec4);
                 
@@ -165,54 +130,16 @@ public static class NN
             weightStride += inputSize;
         }
     }
-
-#if DEBUG
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ClippedReLU(short[] input, short[] bias, short[] output, short min, short max, int offset = 0)
-    {
-        int size = input.Length;
-        int loopSize = size / VSize.Short / UNROLL;
-        Vector<short> minVec = new(min);
-        Vector<short> maxVec = new(max);
-
-        int vectorIndex = 0;
-        for (int i = 0; i < loopSize; i++) {
-            int unrolledIndex = vectorIndex + VSize.Short;
-            int unrolledIndex2 = unrolledIndex + VSize.Short;
-            int unrolledIndex3 = unrolledIndex2 + VSize.Short;
-
-            Vector<short> iVec = input.LoadVector(vectorIndex);
-            Vector<short> bVec = bias.LoadVector(vectorIndex);
-            Vector<short> clamped = (iVec + bVec).Clamp(ref minVec, ref maxVec);
-            clamped.ToArray(output, offset + vectorIndex);
-            
-            Vector<short> iVec2 = input.LoadVector(unrolledIndex);
-            Vector<short> bVec2 = bias.LoadVector(unrolledIndex);
-            Vector<short> clamped2 = (iVec2 + bVec2).Clamp(ref minVec, ref maxVec);
-            clamped2.ToArray(output, offset + unrolledIndex);
-            
-            Vector<short> iVec3 = input.LoadVector(unrolledIndex2);
-            Vector<short> bVec3 = bias.LoadVector(unrolledIndex2);
-            Vector<short> clamped3 = (iVec3 + bVec3).Clamp(ref minVec, ref maxVec);
-            clamped3.ToArray(output, offset + unrolledIndex2);
-            
-            Vector<short> iVec4 = input.LoadVector(unrolledIndex3);
-            Vector<short> bVec4 = bias.LoadVector(unrolledIndex3);
-            Vector<short> clamped4 = (iVec4 + bVec4).Clamp(ref minVec, ref maxVec);
-            clamped4.ToArray(output, offset + unrolledIndex3);
-            
-            vectorIndex = unrolledIndex3 + VSize.Short;
-        }
-    }
-
-#endif
-
+    
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AddToAll(short[] inputA, short[] inputB, short[] delta, int offsetA, int offsetB)
     {
         int size = inputA.Length;
         int loopSize = size / VSize.Short / UNROLL;
+        
+        ref short inputAReference = ref MemoryMarshal.GetArrayDataReference(inputA);
+        ref short inputBReference = ref MemoryMarshal.GetArrayDataReference(inputB);
+        ref short deltaReference = ref MemoryMarshal.GetArrayDataReference(delta);
 
         int vectorIndex = 0;
         for (int i = 0; i < loopSize; i++) {
@@ -220,45 +147,45 @@ public static class NN
             int unrolledIndex2 = unrolledIndex + VSize.Short;
             int unrolledIndex3 = unrolledIndex2 + VSize.Short;
             
-            Vector<short> iAVec = inputA.LoadVector(vectorIndex);
-            Vector<short> dAVec = delta.LoadVector(offsetA + vectorIndex);
+            Vector<short> iAVec = inputAReference.LoadVector(vectorIndex);
+            Vector<short> dAVec = deltaReference.LoadVector(offsetA + vectorIndex);
             Vector<short> rAVec = iAVec + dAVec;
-            rAVec.ToArray(inputA, vectorIndex);
+            rAVec.ToArray(ref inputAReference, vectorIndex);
             
-            Vector<short> iAVec2 = inputA.LoadVector(unrolledIndex);
-            Vector<short> dAVec2 = delta.LoadVector(offsetA + unrolledIndex);
+            Vector<short> iAVec2 = inputAReference.LoadVector(unrolledIndex);
+            Vector<short> dAVec2 = deltaReference.LoadVector(offsetA + unrolledIndex);
             Vector<short> rAVec2 = iAVec2 + dAVec2;
-            rAVec2.ToArray(inputA, unrolledIndex);
+            rAVec2.ToArray(ref inputAReference, unrolledIndex);
             
-            Vector<short> iAVec3 = inputA.LoadVector(unrolledIndex2);
-            Vector<short> dAVec3 = delta.LoadVector(offsetA + unrolledIndex2);
+            Vector<short> iAVec3 = inputAReference.LoadVector(unrolledIndex2);
+            Vector<short> dAVec3 = deltaReference.LoadVector(offsetA + unrolledIndex2);
             Vector<short> rAVec3 = iAVec3 + dAVec3;
-            rAVec3.ToArray(inputA, unrolledIndex2);
+            rAVec3.ToArray(ref inputAReference, unrolledIndex2);
             
-            Vector<short> iAVec4 = inputA.LoadVector(unrolledIndex3);
-            Vector<short> dAVec4 = delta.LoadVector(offsetA + unrolledIndex3);
+            Vector<short> iAVec4 = inputAReference.LoadVector(unrolledIndex3);
+            Vector<short> dAVec4 = deltaReference.LoadVector(offsetA + unrolledIndex3);
             Vector<short> rAVec4 = iAVec4 + dAVec4;
-            rAVec4.ToArray(inputA, unrolledIndex3);
+            rAVec4.ToArray(ref inputAReference, unrolledIndex3);
             
-            Vector<short> iBVec = inputB.LoadVector(vectorIndex);
-            Vector<short> dBVec = delta.LoadVector(offsetB + vectorIndex);
+            Vector<short> iBVec = inputBReference.LoadVector(vectorIndex);
+            Vector<short> dBVec = deltaReference.LoadVector(offsetB + vectorIndex);
             Vector<short> rBVec = iBVec + dBVec;
-            rBVec.ToArray(inputB, vectorIndex);
+            rBVec.ToArray(ref inputBReference, vectorIndex);
             
-            Vector<short> iBVec2 = inputB.LoadVector(unrolledIndex);
-            Vector<short> dBVec2 = delta.LoadVector(offsetB + unrolledIndex);
+            Vector<short> iBVec2 = inputBReference.LoadVector(unrolledIndex);
+            Vector<short> dBVec2 = deltaReference.LoadVector(offsetB + unrolledIndex);
             Vector<short> rBVec2 = iBVec2 + dBVec2;
-            rBVec2.ToArray(inputB, unrolledIndex);
+            rBVec2.ToArray(ref inputBReference, unrolledIndex);
             
-            Vector<short> iBVec3 = inputB.LoadVector(unrolledIndex2);
-            Vector<short> dBVec3 = delta.LoadVector(offsetB + unrolledIndex2);
+            Vector<short> iBVec3 = inputBReference.LoadVector(unrolledIndex2);
+            Vector<short> dBVec3 = deltaReference.LoadVector(offsetB + unrolledIndex2);
             Vector<short> rBVec3 = iBVec3 + dBVec3;
-            rBVec3.ToArray(inputB, unrolledIndex2);
+            rBVec3.ToArray(ref inputBReference, unrolledIndex2);
             
-            Vector<short> iBVec4 = inputB.LoadVector(unrolledIndex3);
-            Vector<short> dBVec4 = delta.LoadVector(offsetB + unrolledIndex3);
+            Vector<short> iBVec4 = inputBReference.LoadVector(unrolledIndex3);
+            Vector<short> dBVec4 = deltaReference.LoadVector(offsetB + unrolledIndex3);
             Vector<short> rBVec4 = iBVec4 + dBVec4;
-            rBVec4.ToArray(inputB, unrolledIndex3);
+            rBVec4.ToArray(ref inputBReference, unrolledIndex3);
 
             vectorIndex = unrolledIndex3 + VSize.Short;
         }
@@ -269,6 +196,10 @@ public static class NN
     {
         int size = inputA.Length;
         int loopSize = size / VSize.Short / UNROLL;
+        
+        ref short inputAReference = ref MemoryMarshal.GetArrayDataReference(inputA);
+        ref short inputBReference = ref MemoryMarshal.GetArrayDataReference(inputB);
+        ref short deltaReference = ref MemoryMarshal.GetArrayDataReference(delta);
 
         int vectorIndex = 0;
         for (int i = 0; i < loopSize; i++) {
@@ -276,45 +207,45 @@ public static class NN
             int unrolledIndex2 = unrolledIndex + VSize.Short;
             int unrolledIndex3 = unrolledIndex2 + VSize.Short;
             
-            Vector<short> iAVec = inputA.LoadVector(vectorIndex);
-            Vector<short> dAVec = delta.LoadVector(offsetA + vectorIndex);
+            Vector<short> iAVec = inputAReference.LoadVector(vectorIndex);
+            Vector<short> dAVec = deltaReference.LoadVector(offsetA + vectorIndex);
             Vector<short> rAVec = iAVec - dAVec;
-            rAVec.ToArray(inputA, vectorIndex);
+            rAVec.ToArray(ref inputAReference, vectorIndex);
             
-            Vector<short> iAVec2 = inputA.LoadVector(unrolledIndex);
-            Vector<short> dAVec2 = delta.LoadVector(offsetA + unrolledIndex);
+            Vector<short> iAVec2 = inputAReference.LoadVector(unrolledIndex);
+            Vector<short> dAVec2 = deltaReference.LoadVector(offsetA + unrolledIndex);
             Vector<short> rAVec2 = iAVec2 - dAVec2;
-            rAVec2.ToArray(inputA, unrolledIndex);
+            rAVec2.ToArray(ref inputAReference, unrolledIndex);
             
-            Vector<short> iAVec3 = inputA.LoadVector(unrolledIndex2);
-            Vector<short> dAVec3 = delta.LoadVector(offsetA + unrolledIndex2);
+            Vector<short> iAVec3 = inputAReference.LoadVector(unrolledIndex2);
+            Vector<short> dAVec3 = deltaReference.LoadVector(offsetA + unrolledIndex2);
             Vector<short> rAVec3 = iAVec3 - dAVec3;
-            rAVec3.ToArray(inputA, unrolledIndex2);
+            rAVec3.ToArray(ref inputAReference, unrolledIndex2);
             
-            Vector<short> iAVec4 = inputA.LoadVector(unrolledIndex3);
-            Vector<short> dAVec4 = delta.LoadVector(offsetA + unrolledIndex3);
+            Vector<short> iAVec4 = inputAReference.LoadVector(unrolledIndex3);
+            Vector<short> dAVec4 = deltaReference.LoadVector(offsetA + unrolledIndex3);
             Vector<short> rAVec4 = iAVec4 - dAVec4;
-            rAVec4.ToArray(inputA, unrolledIndex3);
+            rAVec4.ToArray(ref inputAReference, unrolledIndex3);
             
-            Vector<short> iBVec = inputB.LoadVector(vectorIndex);
-            Vector<short> dBVec = delta.LoadVector(offsetB + vectorIndex);
+            Vector<short> iBVec = inputBReference.LoadVector(vectorIndex);
+            Vector<short> dBVec = deltaReference.LoadVector(offsetB + vectorIndex);
             Vector<short> rBVec = iBVec - dBVec;
-            rBVec.ToArray(inputB, vectorIndex);
+            rBVec.ToArray(ref inputBReference, vectorIndex);
             
-            Vector<short> iBVec2 = inputB.LoadVector(unrolledIndex);
-            Vector<short> dBVec2 = delta.LoadVector(offsetB + unrolledIndex);
+            Vector<short> iBVec2 = inputBReference.LoadVector(unrolledIndex);
+            Vector<short> dBVec2 = deltaReference.LoadVector(offsetB + unrolledIndex);
             Vector<short> rBVec2 = iBVec2 - dBVec2;
-            rBVec2.ToArray(inputB, unrolledIndex);
+            rBVec2.ToArray(ref inputBReference, unrolledIndex);
             
-            Vector<short> iBVec3 = inputB.LoadVector(unrolledIndex2);
-            Vector<short> dBVec3 = delta.LoadVector(offsetB + unrolledIndex2);
+            Vector<short> iBVec3 = inputBReference.LoadVector(unrolledIndex2);
+            Vector<short> dBVec3 = deltaReference.LoadVector(offsetB + unrolledIndex2);
             Vector<short> rBVec3 = iBVec3 - dBVec3;
-            rBVec3.ToArray(inputB, unrolledIndex2);
+            rBVec3.ToArray(ref inputBReference, unrolledIndex2);
             
-            Vector<short> iBVec4 = inputB.LoadVector(unrolledIndex3);
-            Vector<short> dBVec4 = delta.LoadVector(offsetB + unrolledIndex3);
+            Vector<short> iBVec4 = inputBReference.LoadVector(unrolledIndex3);
+            Vector<short> dBVec4 = deltaReference.LoadVector(offsetB + unrolledIndex3);
             Vector<short> rBVec4 = iBVec4 - dBVec4;
-            rBVec4.ToArray(inputB, unrolledIndex3);
+            rBVec4.ToArray(ref inputBReference, unrolledIndex3);
 
             vectorIndex = unrolledIndex3 + VSize.Short;
         }
@@ -326,35 +257,38 @@ public static class NN
         int size = input.Length;
         int loopSize = size / VSize.Short / UNROLL;
 
+        ref short inputReference = ref MemoryMarshal.GetArrayDataReference(input);
+        ref short deltaReference = ref MemoryMarshal.GetArrayDataReference(delta);
+
         int vectorIndex = 0;
         for (int i = 0; i < loopSize; i++) {
             int unrolledIndex = vectorIndex + VSize.Short;
             int unrolledIndex2 = unrolledIndex + VSize.Short;
             int unrolledIndex3 = unrolledIndex2 + VSize.Short;
 
-            Vector<short> iVec = input.LoadVector(vectorIndex);
-            Vector<short> dSVec = delta.LoadVector(offsetS + vectorIndex);
-            Vector<short> dAVec = delta.LoadVector(offsetA + vectorIndex);
+            Vector<short> iVec = inputReference.LoadVector(vectorIndex);
+            Vector<short> dSVec = deltaReference.LoadVector(offsetS + vectorIndex);
+            Vector<short> dAVec = deltaReference.LoadVector(offsetA + vectorIndex);
             Vector<short> rVec = iVec - dSVec + dAVec;
-            rVec.ToArray(input, vectorIndex);
+            rVec.ToArray(ref inputReference, vectorIndex);
             
-            Vector<short> iVec2 = input.LoadVector(unrolledIndex);
-            Vector<short> dSVec2 = delta.LoadVector(offsetS + unrolledIndex);
-            Vector<short> dAVec2 = delta.LoadVector(offsetA + unrolledIndex);
+            Vector<short> iVec2 = inputReference.LoadVector(unrolledIndex);
+            Vector<short> dSVec2 = deltaReference.LoadVector(offsetS + unrolledIndex);
+            Vector<short> dAVec2 = deltaReference.LoadVector(offsetA + unrolledIndex);
             Vector<short> rVec2 = iVec2 - dSVec2 + dAVec2;
-            rVec2.ToArray(input, unrolledIndex);
+            rVec2.ToArray(ref inputReference, unrolledIndex);
             
-            Vector<short> iVec3 = input.LoadVector(unrolledIndex2);
-            Vector<short> dSVec3 = delta.LoadVector(offsetS + unrolledIndex2);
-            Vector<short> dAVec3 = delta.LoadVector(offsetA + unrolledIndex2);
+            Vector<short> iVec3 = inputReference.LoadVector(unrolledIndex2);
+            Vector<short> dSVec3 = deltaReference.LoadVector(offsetS + unrolledIndex2);
+            Vector<short> dAVec3 = deltaReference.LoadVector(offsetA + unrolledIndex2);
             Vector<short> rVec3 = iVec3 - dSVec3 + dAVec3;
-            rVec3.ToArray(input, unrolledIndex2);
+            rVec3.ToArray(ref inputReference, unrolledIndex2);
             
-            Vector<short> iVec4 = input.LoadVector(unrolledIndex3);
-            Vector<short> dSVec4 = delta.LoadVector(offsetS + unrolledIndex3);
-            Vector<short> dAVec4 = delta.LoadVector(offsetA + unrolledIndex3);
+            Vector<short> iVec4 = inputReference.LoadVector(unrolledIndex3);
+            Vector<short> dSVec4 = deltaReference.LoadVector(offsetS + unrolledIndex3);
+            Vector<short> dAVec4 = deltaReference.LoadVector(offsetA + unrolledIndex3);
             Vector<short> rVec4 = iVec4 - dSVec4 + dAVec4;
-            rVec4.ToArray(input, unrolledIndex3);
+            rVec4.ToArray(ref inputReference, unrolledIndex3);
 
             vectorIndex = unrolledIndex3 + VSize.Short;
         }

--- a/Backend/Engine/NNUE/Vectorization/NN.cs
+++ b/Backend/Engine/NNUE/Vectorization/NN.cs
@@ -63,7 +63,7 @@ public static class NN
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static void ClippedReLUFlattenAndForward(short[] inputA, short[] inputB, short[] bias, short[] weight, 
         int[] output, short min, short max, int separationIndex, int offset = 0)
     {

--- a/Backend/Engine/NNUE/Vectorization/VMethod.cs
+++ b/Backend/Engine/NNUE/Vectorization/VMethod.cs
@@ -16,9 +16,21 @@ public static class VMethod
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<T> LoadVector<T>(this ref T value, int index = 0) where T : struct
+    {
+        return Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref value, index)));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ToArray<T>(this Vector<T> vector, T[] array, int offset = 0) where T : struct
     {
         Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref array.AA(offset)), vector);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ToArray<T>(this Vector<T> vector, ref T arrayRef, int offset = 0) where T : struct
+    {
+        Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref arrayRef, offset)), vector);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This PR optimizes away multiple `LEA: Load Effective Address` instructions. This is normally required since .NET GC moves stuff around memory, but the instruction should be only added if it is moved, and not every time.

```
       IN          ACCUMULATOR                               HIDDEN                                    OUT
 ______________      _______      ______________________________________________________________      _____
| WHITE: (768) | -> | (256) | -> | ClippedReLU(0, 1) -> (256) \                                 |    |     |
|              |    |       |    |                             \                                |    |     |
|              |    |       |    |                              CONCATENATE(ColorToMove): (512) | -> | (1) |
|              |    |       |    |                             /                                |    |     |
| BLACK: (768) | -> | (256) | -> | ClippedReLU(0, 1) -> (256) /                                 |    |     |
 --------------      -------      --------------------------------------------------------------      -----

TAG: EXP-0006
Data: 1.7B FEN --- DEPTH: 9 (1.2B) + NODES: 5K (500M)
Batch Size: 500000
Epochs: 80
LR: 5e-3
LR Drop: 30
WDL: 0.4
```

## ELO Difference
Using `UHO_XXL_+0.90_+1.19.epd`:

### TC: 10s + 0.1s (STC)
```
ELO   | 7.02 +- 5.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9608 W: 2648 L: 2454 D: 4506
```

### TC: 60s + 0.6s (LTC)
```
ELO   | 5.19 +- 3.41 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 19072 W: 4705 L: 4420 D: 9947
```
